### PR TITLE
投稿時にはエラーメッセージをクリアする

### DIFF
--- a/src/components/TimesEsa/index.tsx
+++ b/src/components/TimesEsa/index.tsx
@@ -55,6 +55,8 @@ const TimesEsa: React.FC<{}> = () => {
         tagsText={esaTagsText}
         fetching={fetching}
         onSubmit={(md: string, html: string, tags: string[]) => {
+          setfetchErrorMessage('');
+
           setEsaText(md);
           setEsaHtml(html);
           setEsaTagsText(tags.join(', '));


### PR DESCRIPTION
日報がない状態から投稿すると、error messageが残ったままになっているため、新しく投稿された日報が反映されない