### PR TITLE
textfieldは最大30行までの可変にする

### DIFF
--- a/src/components/EsaTextField/index.tsx
+++ b/src/components/EsaTextField/index.tsx
@@ -29,6 +29,7 @@ const EsaTextField: React.FC<EsaTextFieldProps> = (props: EsaTextFieldProps) => 
     <TextField
       fullWidth
       multiline
+      required
       placeholder="ここにつぶやいた内容がesa.ioに追記されていきます"
       variant="outlined"
       InputProps={{
@@ -38,7 +39,8 @@ const EsaTextField: React.FC<EsaTextFieldProps> = (props: EsaTextFieldProps) => 
         },
         disabled: props.sending || props.fetching,
       }}
-      rows={7}
+      minRows={7}
+      maxRows={30}
       value={props.text}
       onChange={props.onChange}
     />


### PR DESCRIPTION
その場でresizeできるのがよいが、現状だと対応するオプションがないので最大長を別に設定する。

- https://mui.com/api/text-field/