### PR TITLE
Esaのresponse errorの型を定義する

### DIFF
--- a/.github/workflows/check_firebase_cloud_function.yaml
+++ b/.github/workflows/check_firebase_cloud_function.yaml
@@ -1,0 +1,18 @@
+name: Firebase Cloud Function部分の確認
+
+on: [push]
+
+jobs:
+  check_firebase_hosting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '12'
+      - run: npm install
+      - run: npm install
+        working-directory: ./functions
+      - run: npm --prefix functions run lint
+      - run: npm --prefix functions run build

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -52,6 +52,12 @@ export type EsaTags = {
   tags: Tag[]
 }
 
+// ref: https://docs.esa.io/posts/102#%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9
+type EsaErrorResponse = {
+  error: string;
+  message: string;
+}
+
 function transformTitle(oldTitle: string, newTitle: string): string {
   const result = Array.from(new Set(oldTitle.split(/,\s?|、/).concat(newTitle.split(/,\s?|、/))));
   if (JSON.stringify(result) === JSON.stringify(['日報'])) {
@@ -86,7 +92,8 @@ async function createOrUpdatePost(
       },
     }).then((res: AxiosResponse<EsaPost>) => {
       return res.data;
-    }).catch((err: AxiosError) => {
+    }).catch((err: AxiosError<EsaErrorResponse>) => {
+      err.response?.statusText
       throw new functions.https.HttpsError('invalid-argument', `${err.response?.data.error}: ${err.response?.data.message}`);
     });
   }
@@ -102,7 +109,7 @@ async function createOrUpdatePost(
       },
     }).then((res: AxiosResponse<EsaPost>) => {
       return res.data;
-    }).catch((err: AxiosError) => {
+    }).catch((err: AxiosError<EsaErrorResponse>) => {
       throw new functions.https.HttpsError('invalid-argument', `${err.response?.data.error}: ${err.response?.data.message}`);
     });
   }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -93,7 +93,6 @@ async function createOrUpdatePost(
     }).then((res: AxiosResponse<EsaPost>) => {
       return res.data;
     }).catch((err: AxiosError<EsaErrorResponse>) => {
-      err.response?.statusText
       throw new functions.https.HttpsError('invalid-argument', `${err.response?.data.error}: ${err.response?.data.message}`);
     });
   }


### PR DESCRIPTION
ref:

- https://github.com/syou6162/times_esa/pull/354
- https://github.com/syou6162/times_esa/runs/6282937990?check_suite_focus=true

Esa側のerror responseがunknownになっているため、buildエラーでこけるようになっていた(多分、[これ](https://github.com/axios/axios/pull/3645)の影響?)。axiosの型パラメータに渡せるようにEsaのresponse errorの型を定義する。