### PR TITLE
renovateでも--legacy-peer-depsを有効にするため、.npmrcを追加する

### DIFF
--- a/.github/workflows/check_firebase_cloud_function.yaml
+++ b/.github/workflows/check_firebase_cloud_function.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - run: npm install --legacy-peer-deps
+      - run: npm install
       - run: npm install
         working-directory: ./functions
       - run: npm --prefix functions run lint

--- a/.github/workflows/check_firebase_hosting.yaml
+++ b/.github/workflows/check_firebase_hosting.yaml
@@ -11,6 +11,6 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '16'
-    - run: npm install --legacy-peer-deps
+    - run: npm install
     - run: npm run-script build          
     - run: npm test

--- a/.github/workflows/deploy_firebase_clooud_function.yaml
+++ b/.github/workflows/deploy_firebase_clooud_function.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - run: npm install --legacy-peer-deps
+      - run: npm install
       - run: npm install
         working-directory: ./functions
       - run: npm --prefix functions run lint

--- a/.github/workflows/deploy_firebase_hosting.yaml
+++ b/.github/workflows/deploy_firebase_hosting.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - run: npm install --legacy-peer-deps
+      - run: npm install
       - name: Build React app
         env:
           REACT_APP_API_KEY: ${{ secrets.REACT_APP_API_KEY }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
このあたりが出るのを抑制する。

```
% npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: @testing-library/react@13.3.0
npm ERR! Found: react@17.0.0
npm ERR! node_modules/react
npm ERR!   react@"^17.0.0" from the root project
npm ERR!   peer react@">=16.8.0" from @emotion/react@11.10.0
npm ERR!   node_modules/@emotion/react
npm ERR!     @emotion/react@"^11.10.0" from the root project
npm ERR!     peer @emotion/react@"^11.0.0-rc.0" from @emotion/styled@11.10.0
npm ERR!     node_modules/@emotion/styled
npm ERR!       @emotion/styled@"^11.10.0" from the root project
npm ERR!       4 more (@mui/lab, @mui/material, @mui/styled-engine, @mui/system)
npm ERR!     4 more (@mui/lab, @mui/material, @mui/styled-engine, @mui/system)
npm ERR!   13 more (@emotion/styled, @mui/base, @mui/lab, @mui/material, ...)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^18.0.0" from @testing-library/react@13.3.0
npm ERR! node_modules/@testing-library/react
npm ERR!   dev @testing-library/react@"13.3.0" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: react@18.2.0
npm ERR! node_modules/react
npm ERR!   peer react@"^18.0.0" from @testing-library/react@13.3.0
npm ERR!   node_modules/@testing-library/react
npm ERR!     dev @testing-library/react@"13.3.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/yasuhisa/.npm/eresolve-report.txt for a full report.
```