### PR TITLE
Fix esa form state handling

### DIFF
--- a/src/components/EsaSubmitForm/index.spec.tsx
+++ b/src/components/EsaSubmitForm/index.spec.tsx
@@ -81,6 +81,29 @@ describe('times_esaのフォームが正しく機能する(正常系)', () => {
     });
   });
 
+  it('propsが更新されても入力中のテキストは保持される', async () => {
+    const props: EsaSubmitFormProps = {
+      category: '',
+      title: 'こんにちは',
+      tags: [],
+      tagCandidates: [],
+      fetching: false,
+      onSubmit: () => { },
+    }
+    const { rerender, getByPlaceholderText } = render(
+      <EsaSubmitForm {...props} />
+    );
+
+    const textArea = getByPlaceholderText('ここにつぶやいた内容がesa.ioに追記されていきます');
+    fireEvent.change(textArea, { target: { value: 'keep' } });
+
+    rerender(
+      <EsaSubmitForm {...props} title="更新後" tags={["new"]} />
+    );
+
+    expect((getByPlaceholderText('ここにつぶやいた内容がesa.ioに追記されていきます') as HTMLInputElement).value).toBe('keep');
+  });
+
   it('投稿後の内容が画面に正しく反映される', async () => {
     const props: EsaSubmitFormProps = {
       category: "",
@@ -90,13 +113,15 @@ describe('times_esaのフォームが正しく機能する(正常系)', () => {
       fetching: false,
       onSubmit: () => { },
     }
-    const { getByTitle, getByText, asFragment } = render(
+    const { getByTitle, getByText, getByPlaceholderText, asFragment } = render(
       <EsaSubmitForm {...props} />
     );
 
     expect(mockHttpsCallable).toBeCalledTimes(0)
-    expect(asFragment()).toMatchSnapshot();
     const before = asFragment();
+
+    const textArea = getByPlaceholderText('ここにつぶやいた内容がesa.ioに追記されていきます');
+    fireEvent.change(textArea, { target: { value: 'hello' } });
 
     fireEvent.click(getByTitle("esa_submit_form_button"));
 
@@ -106,6 +131,7 @@ describe('times_esaのフォームが正しく機能する(正常系)', () => {
       expect(getByText("BigQuery")).toBeDefined();
       expect(getByText(modifiedTitle)).toBeDefined();
       expect(asFragment()).not.toStrictEqual(before);
+      expect((getByPlaceholderText('ここにつぶやいた内容がesa.ioに追記されていきます') as HTMLInputElement).value).toBe('');
     });
   });
 });
@@ -135,10 +161,12 @@ describe('times_esaのフォームが正しく機能する(異常系)', () => {
       fetching: false,
       onSubmit: () => { },
     }
-    const { getByTitle, asFragment } = render(
+    const { getByTitle, getByPlaceholderText, asFragment } = render(
       <EsaSubmitForm {...props} />
     );
 
+    const textArea = getByPlaceholderText('ここにつぶやいた内容がesa.ioに追記されていきます');
+    fireEvent.change(textArea, { target: { value: 'fail' } });
     const before = asFragment();
 
     fireEvent.click(getByTitle("esa_submit_form_button"));
@@ -150,7 +178,7 @@ describe('times_esaのフォームが正しく機能する(異常系)', () => {
 
       // 変更に失敗したので、DOMに変わりはない
       expect(asFragment()).toStrictEqual(before);
-      expect(asFragment()).toMatchSnapshot();
+      expect((getByPlaceholderText('ここにつぶやいた内容がesa.ioに追記されていきます') as HTMLInputElement).value).toBe('fail');
     });
   });
 });

--- a/src/components/EsaSubmitForm/index.tsx
+++ b/src/components/EsaSubmitForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@mui/material';
 import { format } from 'date-fns';
 import { getFunctions, httpsCallable, HttpsCallableResult } from 'firebase/functions';
@@ -102,6 +102,18 @@ export const EsaSubmitForm: React.FC<EsaSubmitFormProps> = (props: EsaSubmitForm
   const [text, setText] = useState<string>('');
   const [tags, setTags] = useState<string[]>(props.tags);
 
+  useEffect(() => {
+    setCategory(props.category);
+  }, [props.category]);
+
+  useEffect(() => {
+    setTitle(props.title);
+  }, [props.title]);
+
+  useEffect(() => {
+    setTags(props.tags);
+  }, [props.tags]);
+
   const isSameCategory = (): boolean => {
     if (category === '') { // 今日の日報がまだ作成されていない
       return true;
@@ -114,16 +126,17 @@ export const EsaSubmitForm: React.FC<EsaSubmitFormProps> = (props: EsaSubmitForm
     e.preventDefault();
     setSending(true);
     const date = new Date();
-    await submitTextToEsa(
-      makeDefaultEsaCategory(date),
-      tags.concat(getDay(date)),
-      transformTitle(title),
-      text !== '' ? `${format(date, 'HH:mm')} ${text}\n\n---\n` : '',
-    ).then((data) => {
+    try {
+      const data = await submitTextToEsa(
+        makeDefaultEsaCategory(date),
+        tags.concat(getDay(date)),
+        transformTitle(title),
+        text !== '' ? `${format(date, 'HH:mm')} ${text}\n\n---\n` : '',
+      );
       setCategory(data.data.category);
       setTitle(data.data.name);
-      setText('');
       setTags(data.data.tags);
+      setText('');
       props.onSubmit(
         data.data.category,
         data.data.name,
@@ -131,12 +144,12 @@ export const EsaSubmitForm: React.FC<EsaSubmitFormProps> = (props: EsaSubmitForm
         data.data.body_html,
         data.data.tags,
       );
-    }).catch((err: Error) => {
+    } catch (err: any) {
       // eslint-disable-next-line no-alert
       alert(`${err.name}: ${err.message}`);
-    }).finally(() => {
+    } finally {
       setSending(false);
-    });
+    }
   };
 
   return (

--- a/src/components/TimesEsa/index.tsx
+++ b/src/components/TimesEsa/index.tsx
@@ -144,7 +144,7 @@ const TimesEsa: React.FC<TimesEsaProps> = (props: TimesEsaProps) => {
       </a>
       {`: 今日は${getPostsCount(esaText)}個つぶやいたよ`}
       <EsaSubmitForm
-        key={`esa_form_${esaUpdatedAt}_${esaTitle}_${esaCategory}_${esaTags.join(',')}`}
+        key="esa_form"
         category={esaCategory}
         title={esaTitle}
         tags={esaTags}


### PR DESCRIPTION
## Summary
- keep EsaSubmitForm mounted using constant key in TimesEsa
- sync EsaSubmitForm state from props via `useEffect`
- clear text only on successful submission
- preserve text on submission failure
- ensure text field stays when props change
- update and extend tests

## Testing
- `npx vitest run`