### PR TITLE
Fix React key warnings in tests

### DIFF
--- a/src/components/EsaTagsField/index.tsx
+++ b/src/components/EsaTagsField/index.tsx
@@ -64,11 +64,13 @@ export const EsaTagsField: React.FC<EsaTagsFieldProps> = (props: EsaTagsFieldPro
       }}
       renderTags={(tagValue, getTagProps) => {
         return tagValue.map((tag, index) => {
+          const { key, ...tagProps } = getTagProps({ index });
           return (
             <Chip
+              key={key}
               label={tag}
               color="secondary"
-              {...getTagProps({ index })}
+              {...tagProps}
             />
           );
         });


### PR DESCRIPTION
## Summary
- handle React key property separately in `EsaTagsField`

## Testing
- `npx vitest run`