### PR TITLE
Add concurrency to Firebase deployment workflows

### DIFF
--- a/.github/workflows/deploy_firebase_clooud_function.yaml
+++ b/.github/workflows/deploy_firebase_clooud_function.yaml
@@ -3,6 +3,9 @@ name: Firebase Cloud Functionsでのdeployを実行する
 on:
   push:
     branches: [ master ]
+concurrency:
+  group: firebase-functions-deploy-production
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/deploy_firebase_hosting.yaml
+++ b/.github/workflows/deploy_firebase_hosting.yaml
@@ -3,6 +3,9 @@ name: Firebase Hostingでのdeployを実行する
 on:
   push:
     branches: [ master ]
+concurrency:
+  group: firebase-hosting-deploy-production
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- serialize deploy workflows with concurrency groups
- use distinct concurrency groups for functions and hosting

## Testing
- `npm test`
