### PR TITLE
フロントエンドの型定義を整理・一元化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import {
 import { firebaseAuth } from './firebase/index';
 import { Body } from './components/Body';
 import { Footer } from './components/Footer';
-import { GoogleUser } from './util';
+import { GoogleUser } from './types';
 import { config } from './config';
 
 const App: React.FC = () => {

--- a/src/components/Body/index.spec.tsx
+++ b/src/components/Body/index.spec.tsx
@@ -3,7 +3,8 @@ process.env.VITE_VALID_MAIL_ADDRESSES = 'valid@example.com';
 
 import { render } from '@testing-library/react'
 import { describe, it, expect, vi } from "vitest"
-import { Body, BodyProps } from '.'
+import { Body } from '.'
+import { BodyProps } from '../../types/components'
 import { getAuth } from 'firebase/auth';
 
 // 認証の画面をmock

--- a/src/components/Body/index.tsx
+++ b/src/components/Body/index.tsx
@@ -10,7 +10,7 @@ import WelcomeMessage from '../WelcomeMessage';
 import SignOutButton from '../SignOutButton';
 
 
-export { BodyProps } from '../../types/components';
+export type { BodyProps } from '../../types/components';
 
 export const Body: React.FC<BodyProps> = (props: BodyProps) => {
   const isShowSignedInDialog = (): boolean => {

--- a/src/components/Body/index.tsx
+++ b/src/components/Body/index.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 import { Auth } from 'firebase/auth';
-import { GoogleUser, isValidEmail } from '../../util';
+import { isValidEmail } from '../../util';
+import { GoogleUser } from '../../types';
+import { BodyProps } from '../../types/components';
 import { config } from '../../config';
 import TimesEsa from '../TimesEsa';
 import SignInDialog from '../SignInDialog';
 import WelcomeMessage from '../WelcomeMessage';
 import SignOutButton from '../SignOutButton';
 
-export type BodyProps = {
-  hasUserLanded: boolean;
-  isSignedIn: boolean;
-  user: GoogleUser;
-  firebaseAuth: Auth | null;
-}
 
 export const Body: React.FC<BodyProps> = (props: BodyProps) => {
   const isShowSignedInDialog = (): boolean => {

--- a/src/components/Body/index.tsx
+++ b/src/components/Body/index.tsx
@@ -9,9 +9,6 @@ import SignInDialog from '../SignInDialog';
 import WelcomeMessage from '../WelcomeMessage';
 import SignOutButton from '../SignOutButton';
 
-
-export type { BodyProps } from '../../types/components';
-
 export const Body: React.FC<BodyProps> = (props: BodyProps) => {
   const isShowSignedInDialog = (): boolean => {
     return props.hasUserLanded && !props.isSignedIn;

--- a/src/components/Body/index.tsx
+++ b/src/components/Body/index.tsx
@@ -10,6 +10,8 @@ import WelcomeMessage from '../WelcomeMessage';
 import SignOutButton from '../SignOutButton';
 
 
+export { BodyProps } from '../../types/components';
+
 export const Body: React.FC<BodyProps> = (props: BodyProps) => {
   const isShowSignedInDialog = (): boolean => {
     return props.hasUserLanded && !props.isSignedIn;

--- a/src/components/DailyReport/index.spec.tsx
+++ b/src/components/DailyReport/index.spec.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { describe, it, expect } from "vitest"
-import { DailyReport, DailyReportProps } from '.'
+import { DailyReport } from '.'
+import { DailyReportProps } from '../../types/components'
 
 describe('DailyReportが正しく表示される', () => {
   it('ディフォルトではhtmlが表示される', () => {

--- a/src/components/DailyReport/index.tsx
+++ b/src/components/DailyReport/index.tsx
@@ -87,9 +87,6 @@ const DailyReportShare: React.FC<DailyReportShareProps> = (props: DailyReportSha
 };
 
 
-
-export type { DailyReportProps } from '../../types/components';
-
 export const DailyReport: React.FC<DailyReportProps> = (props: DailyReportProps) => {
   const [dailyReportType, setDailyReportType] = useState<DailyReportType>(DailyReportType.HTML);
 

--- a/src/components/DailyReport/index.tsx
+++ b/src/components/DailyReport/index.tsx
@@ -88,6 +88,8 @@ const DailyReportShare: React.FC<DailyReportShareProps> = (props: DailyReportSha
 
 
 
+export { DailyReportProps } from '../../types/components';
+
 export const DailyReport: React.FC<DailyReportProps> = (props: DailyReportProps) => {
   const [dailyReportType, setDailyReportType] = useState<DailyReportType>(DailyReportType.HTML);
 

--- a/src/components/DailyReport/index.tsx
+++ b/src/components/DailyReport/index.tsx
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import { Button } from '@mui/material';
 import { CopyButton } from './share_button/copy_button';
 import { TweetButton } from './share_button/tweet_button';
+import { DailyReportType } from '../../types';
+import { DailyReportProps, DailyReportHtmlProps, DailyReportTextProps, DailyReportShareProps } from '../../types/components';
 
-type DailyReportHtmlProps = {
-  esaHtml: string;
-};
 
 const DailyReportHtml: React.FC<DailyReportHtmlProps> = (props: DailyReportHtmlProps) => {
   return (
@@ -23,9 +22,6 @@ const DailyReportHtml: React.FC<DailyReportHtmlProps> = (props: DailyReportHtmlP
   );
 };
 
-type DailyReportTextProps = {
-  esaText: string;
-};
 
 const DailyReportText: React.FC<DailyReportTextProps> = (props: DailyReportTextProps) => {
   return (
@@ -42,9 +38,6 @@ const DailyReportText: React.FC<DailyReportTextProps> = (props: DailyReportTextP
   );
 };
 
-type DailyReportShareProps = {
-  esaText: string;
-}
 
 const DailyReportShare: React.FC<DailyReportShareProps> = (props: DailyReportShareProps) => {
   const texts = `${props.esaText}\n\n`.replace(/(\r\n|\n|\r)/gm, '\n')
@@ -93,24 +86,7 @@ const DailyReportShare: React.FC<DailyReportShareProps> = (props: DailyReportSha
   );
 };
 
-export type DailyReportProps = {
-  fetching: boolean;
-  fetchErrorMessage: string;
 
-  esaText: string;
-  esaHtml: string;
-  reloadDailyReport: () => void;
-};
-
-// eslint-disable-next-line no-shadow, no-unused-vars
-enum DailyReportType {
-  // eslint-disable-next-line no-unused-vars
-  HTML = 'HTML',
-  // eslint-disable-next-line no-unused-vars
-  TEXT = 'TEXT',
-  // eslint-disable-next-line no-unused-vars
-  SHARE = 'SHARE',
-}
 
 export const DailyReport: React.FC<DailyReportProps> = (props: DailyReportProps) => {
   const [dailyReportType, setDailyReportType] = useState<DailyReportType>(DailyReportType.HTML);

--- a/src/components/DailyReport/index.tsx
+++ b/src/components/DailyReport/index.tsx
@@ -88,7 +88,7 @@ const DailyReportShare: React.FC<DailyReportShareProps> = (props: DailyReportSha
 
 
 
-export { DailyReportProps } from '../../types/components';
+export type { DailyReportProps } from '../../types/components';
 
 export const DailyReport: React.FC<DailyReportProps> = (props: DailyReportProps) => {
   const [dailyReportType, setDailyReportType] = useState<DailyReportType>(DailyReportType.HTML);

--- a/src/components/DailyReport/share_button/copy_button.tsx
+++ b/src/components/DailyReport/share_button/copy_button.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
 import { Button } from '@mui/material';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { CopyButtonProps } from '../../../types/components';
 
-export type CopyButtonProps = {
-  text: string;
-};
 
 export const CopyButton: React.FC<CopyButtonProps> = (props: CopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false);

--- a/src/components/DailyReport/share_button/tweet_button.tsx
+++ b/src/components/DailyReport/share_button/tweet_button.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Button } from '@mui/material';
+import { TweetButtonProps } from '../../../types/components';
 
-export type TweetButtonProps = {
-  text: string;
-};
 
 export const TweetButton: React.FC<TweetButtonProps> = (props: TweetButtonProps) => {
   const tweet = `https://x.com/intent/post?text=${encodeURIComponent(props.text)}`;

--- a/src/components/EsaSubmitForm/index.spec.tsx
+++ b/src/components/EsaSubmitForm/index.spec.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { EsaSubmitForm, EsaSubmitFormProps, getDay } from '.'
+import { EsaSubmitForm, getDay } from '.'
+import { EsaSubmitFormProps } from '../../types/components'
 import { makeDefaultEsaCategory } from '../../util';
 import * as api from '../../api';
 

--- a/src/components/EsaSubmitForm/index.tsx
+++ b/src/components/EsaSubmitForm/index.tsx
@@ -47,6 +47,8 @@ export const submitTextToEsa = (
   return submitTextToEsaApi(category, tags, title, text);
 };
 
+export { EsaSubmitFormProps } from '../../types/components';
+
 export const EsaSubmitForm: React.FC<EsaSubmitFormProps> = (props: EsaSubmitFormProps) => {
   const [sending, setSending] = useState(false);
   const [category, setCategory] = useState<string>(props.category);

--- a/src/components/EsaSubmitForm/index.tsx
+++ b/src/components/EsaSubmitForm/index.tsx
@@ -47,7 +47,7 @@ export const submitTextToEsa = (
   return submitTextToEsaApi(category, tags, title, text);
 };
 
-export { EsaSubmitFormProps } from '../../types/components';
+export type { EsaSubmitFormProps } from '../../types/components';
 
 export const EsaSubmitForm: React.FC<EsaSubmitFormProps> = (props: EsaSubmitFormProps) => {
   const [sending, setSending] = useState(false);

--- a/src/components/EsaSubmitForm/index.tsx
+++ b/src/components/EsaSubmitForm/index.tsx
@@ -7,23 +7,8 @@ import EsaTextField from '../EsaTextField';
 import { EsaTagsField } from '../EsaTagsField';
 import { makeDefaultEsaCategory } from '../../util';
 import { submitTextToEsa as submitTextToEsaApi } from '../../api';
+import { EsaSubmitFormProps } from '../../types/components';
 
-export type EsaSubmitFormProps = {
-  category: string;
-  title: string;
-  tags: string[];
-  tagCandidates: string[];
-  fetching: boolean;
-  onSubmit: (
-    /* eslint-disable no-unused-vars */
-    category: string,
-    title: string,
-    markdown: string,
-    html: string,
-    tags: string[]
-    /* eslint-enable no-unused-vars */
-  ) => void;
-};
 
 export function getDay(date: Date): string {
   const day = date.getDay();

--- a/src/components/EsaSubmitForm/index.tsx
+++ b/src/components/EsaSubmitForm/index.tsx
@@ -47,8 +47,6 @@ export const submitTextToEsa = (
   return submitTextToEsaApi(category, tags, title, text);
 };
 
-export type { EsaSubmitFormProps } from '../../types/components';
-
 export const EsaSubmitForm: React.FC<EsaSubmitFormProps> = (props: EsaSubmitFormProps) => {
   const [sending, setSending] = useState(false);
   const [category, setCategory] = useState<string>(props.category);

--- a/src/components/EsaTagsField/index.spec.tsx
+++ b/src/components/EsaTagsField/index.spec.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { render } from '@testing-library/react'
 import { describe, it, expect } from "vitest"
-import { EsaTagsField, EsaTagsFieldProps } from '.'
+import { EsaTagsField } from '.'
+import { EsaTagsFieldProps } from '../../types/components'
 
 describe('esaのタグが正しく表示される', () => {
   it('tagsもtagCandidatesも空の状態', () => {

--- a/src/components/EsaTagsField/index.tsx
+++ b/src/components/EsaTagsField/index.tsx
@@ -19,8 +19,6 @@ const TagTextField = styled(TextField)({
   },
 });
 
-export type { EsaTagsFieldProps } from '../../types/components';
-
 export const EsaTagsField: React.FC<EsaTagsFieldProps> = (props: EsaTagsFieldProps) => {
   return (
     <Autocomplete

--- a/src/components/EsaTagsField/index.tsx
+++ b/src/components/EsaTagsField/index.tsx
@@ -2,28 +2,11 @@ import React from 'react';
 import { TextField } from '@mui/material';
 import { styled } from '@mui/system';
 import Autocomplete, {
-  AutocompleteChangeReason,
-  AutocompleteChangeDetails,
   AutocompleteRenderInputParams,
 } from '@mui/material/Autocomplete';
 import Chip from '@mui/material/Chip';
+import { EsaTagsFieldProps } from '../../types/components';
 
-export type EsaTagsFieldProps = {
-  sending: boolean;
-  fetching: boolean;
-  tags: string[];
-  tagCandidates: string[];
-  onChange: (
-    // eslint-disable-next-line no-unused-vars
-    event: React.ChangeEvent<{}>,
-    // eslint-disable-next-line no-unused-vars
-    value: string[],
-    // eslint-disable-next-line no-unused-vars
-    reason: AutocompleteChangeReason,
-    // eslint-disable-next-line no-unused-vars
-    details?: AutocompleteChangeDetails<string> | undefined
-  ) => void;
-};
 
 const TagTextField = styled(TextField)({
   '& .MuiOutlinedInput-input': {

--- a/src/components/EsaTagsField/index.tsx
+++ b/src/components/EsaTagsField/index.tsx
@@ -19,7 +19,7 @@ const TagTextField = styled(TextField)({
   },
 });
 
-export { EsaTagsFieldProps } from '../../types/components';
+export type { EsaTagsFieldProps } from '../../types/components';
 
 export const EsaTagsField: React.FC<EsaTagsFieldProps> = (props: EsaTagsFieldProps) => {
   return (

--- a/src/components/EsaTagsField/index.tsx
+++ b/src/components/EsaTagsField/index.tsx
@@ -19,6 +19,8 @@ const TagTextField = styled(TextField)({
   },
 });
 
+export { EsaTagsFieldProps } from '../../types/components';
+
 export const EsaTagsField: React.FC<EsaTagsFieldProps> = (props: EsaTagsFieldProps) => {
   return (
     <Autocomplete

--- a/src/components/EsaTextField/index.tsx
+++ b/src/components/EsaTextField/index.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { outlinedInputClasses, TextField } from '@mui/material';
 import { styled } from '@mui/system';
+import { EsaTextFieldProps } from '../../types/components';
 
-type EsaTextFieldProps = {
-  sending: boolean;
-  text: string;
-  // eslint-disable-next-line no-unused-vars
-  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-};
 
 const ContentTextField = styled(TextField)({
   [`& .${outlinedInputClasses.input}`]: {

--- a/src/components/EsaTitleField/index.tsx
+++ b/src/components/EsaTitleField/index.tsx
@@ -3,14 +3,8 @@ import { outlinedInputClasses, TextField } from '@mui/material';
 import { styled } from '@mui/system';
 
 import { moveCursorToEnd } from '../../util';
+import { EsaTitleFieldProps } from '../../types/components';
 
-type EsaTitleFieldProps = {
-  sending: boolean;
-  fetching: boolean;
-  title: string;
-  // eslint-disable-next-line no-unused-vars
-  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-};
 
 const TitleTextField = styled(TextField)({
   [`& .${outlinedInputClasses.input}`]: {

--- a/src/components/Footer/index.spec.tsx
+++ b/src/components/Footer/index.spec.tsx
@@ -3,7 +3,8 @@ import.meta.env.VITE_VALID_MAIL_ADDRESSES = 'valid@example.com';
 
 import { render } from '@testing-library/react'
 import { describe, it, expect } from "vitest"
-import { Footer, FooterProps } from '.'
+import { Footer } from '.'
+import { FooterProps } from '../../types/components'
 
 describe('Footerが正しく表示される', () => {
   it('サインインしていない状態', () => {

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import { Auth } from 'firebase/auth';
 import WelcomeMessage from '../WelcomeMessage';
 import SignOutButton from '../SignOutButton';
-import { GoogleUser, isValidEmail } from '../../util';
+import { isValidEmail } from '../../util';
 import { config } from '../../config';
+import { GoogleUser } from '../../types';
+import { FooterProps } from '../../types/components';
 
-export type FooterProps = {
-  isSignedIn: boolean;
-  user: GoogleUser;
-  firebaseAuth: Auth | null;
-}
 
 export const Footer: React.FC<FooterProps> = (props: FooterProps) => {
   const hr = (

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -6,9 +6,6 @@ import { config } from '../../config';
 import { GoogleUser } from '../../types';
 import { FooterProps } from '../../types/components';
 
-
-export type { FooterProps } from '../../types/components';
-
 export const Footer: React.FC<FooterProps> = (props: FooterProps) => {
   const hr = (
     <hr style={{

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -7,6 +7,8 @@ import { GoogleUser } from '../../types';
 import { FooterProps } from '../../types/components';
 
 
+export { FooterProps } from '../../types/components';
+
 export const Footer: React.FC<FooterProps> = (props: FooterProps) => {
   const hr = (
     <hr style={{

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -7,7 +7,7 @@ import { GoogleUser } from '../../types';
 import { FooterProps } from '../../types/components';
 
 
-export { FooterProps } from '../../types/components';
+export type { FooterProps } from '../../types/components';
 
 export const Footer: React.FC<FooterProps> = (props: FooterProps) => {
   const hr = (

--- a/src/components/SignInDialog/index.tsx
+++ b/src/components/SignInDialog/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Auth, GoogleAuthProvider } from 'firebase/auth';
+import { GoogleAuthProvider } from 'firebase/auth';
 import StyledFirebaseAuth from '../StyledFirebaseAuth';
+import { SignInDialogProps } from '../../types/components';
 
-export type SignInDialogProps = {
-  firebaseAuth: Auth | null;
-}
 
 const SignInDialog: React.FC<SignInDialogProps> = (props: SignInDialogProps) => {
   const uiConfig = {

--- a/src/components/SignOutButton/index.tsx
+++ b/src/components/SignOutButton/index.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { Button } from '@mui/material';
-import { Auth } from 'firebase/auth';
+import { SignOutButtonProps } from '../../types/components';
 
-type SignOutButtonProps = {
-  firebaseAuth: Auth | null;
-}
 
 const SignOutButton: React.FC<SignOutButtonProps> = (props: SignOutButtonProps) => {
   return (

--- a/src/components/StyledFirebaseAuth/index.tsx
+++ b/src/components/StyledFirebaseAuth/index.tsx
@@ -3,12 +3,12 @@ import React, { useEffect, useRef, useState } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
 import * as firebaseui from 'firebaseui';
 import 'firebaseui/dist/firebaseui.css';
+import { StyledFirebaseAuthProps } from '../../types/components';
 
-type Props = {
+type Props = StyledFirebaseAuthProps & {
   // The Firebase UI Web UI Config object.
   // See: https://github.com/firebase/firebaseui-web#configuration
   uiConfig: firebaseui.auth.Config;
-  firebaseAuth: any; // As firebaseui-web
 }
 
 const StyledFirebaseAuth = (props: Props) => {

--- a/src/components/StyledFirebaseAuth/index.tsx
+++ b/src/components/StyledFirebaseAuth/index.tsx
@@ -24,12 +24,12 @@ const StyledFirebaseAuth = (props: Props) => {
     }
 
     // We track the auth state to reset firebaseUi if the user signs out.
-    const unregisterAuthObserver = onAuthStateChanged(props.firebaseAuth, (user) => {
+    const unregisterAuthObserver = props.firebaseAuth ? onAuthStateChanged(props.firebaseAuth, (user) => {
       if (!user && userSignedIn) {
         firebaseUiWidget.reset();
       }
       setUserSignedIn(!!user);
-    });
+    }) : () => {};
 
     // Render the firebaseUi Widget.
     // @ts-ignore

--- a/src/components/TimesEsa/index.tsx
+++ b/src/components/TimesEsa/index.tsx
@@ -5,20 +5,15 @@ import DailyReport from '../DailyReport';
 import { EsaSubmitForm } from '../EsaSubmitForm';
 import { makeDefaultEsaCategory } from '../../util';
 import { getDailyReport, getTagList } from '../../api';
+import { Tag } from '../../types';
+import { TimesEsaProps } from '../../types/components';
 
-export type Tag = {
-  name: string;
-  posts_count: number; // eslint-disable-line camelcase
-}
 
 
 const getPostsCount = (md: string): number => {
   return md.split('---').length - 1;
 };
 
-type TimesEsaProps = {
-  canFetchCloudFunctionEndpoints: boolean;
-};
 
 const TimesEsa: React.FC<TimesEsaProps> = (props: TimesEsaProps) => {
   const [fetching, setFetching] = useState(false);

--- a/src/components/WelcomeMessage/index.tsx
+++ b/src/components/WelcomeMessage/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GoogleUser } from '../../util';
+import { GoogleUser } from '../../types';
 
 const WelcomeMessage: React.FC<GoogleUser> = (props: GoogleUser) => {
   return (

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -114,5 +114,3 @@ export type FooterProps = {
   user: GoogleUser;
   firebaseAuth: Auth | null;
 }
-
-// WelcomeMessage Props (GoogleUserと同じなので、GoogleUserを使う)

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,0 +1,116 @@
+// コンポーネントのProps型定義をまとめたファイル
+
+import { Auth } from 'firebase/auth';
+import { AutocompleteChangeReason, AutocompleteChangeDetails } from '@mui/material';
+import { GoogleUser } from './index';
+
+// Body Component Props
+export type BodyProps = {
+  hasUserLanded: boolean;
+  isSignedIn: boolean;
+  user: GoogleUser;
+  firebaseAuth: Auth | null;
+}
+
+// DailyReport Component Props
+export type DailyReportProps = {
+  fetching: boolean;
+  fetchErrorMessage: string;
+  esaText: string;
+  esaHtml: string;
+  reloadDailyReport: () => void;
+}
+
+// DailyReport内部のコンポーネントProps
+export type DailyReportHtmlProps = {
+  esaHtml: string;
+}
+
+export type DailyReportTextProps = {
+  esaText: string;
+}
+
+export type DailyReportShareProps = {
+  esaText: string;
+}
+
+// ShareButton Props
+export type TweetButtonProps = {
+  text: string;
+}
+
+export type CopyButtonProps = {
+  text: string;
+}
+
+// EsaSubmitForm Props
+export type EsaSubmitFormProps = {
+  category: string;
+  title: string;
+  tags: string[];
+  tagCandidates: string[];
+  fetching: boolean;
+  onSubmit: (
+    category: string,
+    title: string,
+    markdown: string,
+    html: string,
+    tags: string[]
+  ) => void;
+}
+
+// EsaTitleField Props
+export type EsaTitleFieldProps = {
+  fetching: boolean;
+  sending: boolean;
+  title: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+// EsaTextField Props
+export type EsaTextFieldProps = {
+  sending: boolean;
+  text: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+// EsaTagsField Props
+export type EsaTagsFieldProps = {
+  fetching: boolean;
+  sending: boolean;
+  tags: string[];
+  tagCandidates: string[];
+  onChange: (
+    event: React.SyntheticEvent,
+    value: string[],
+    reason: AutocompleteChangeReason,
+    detail?: AutocompleteChangeDetails<string>
+  ) => void;
+}
+
+// TimesEsa Props
+export type TimesEsaProps = {
+  canFetchCloudFunctionEndpoints: boolean;
+}
+
+// SignInDialog Props
+export type SignInDialogProps = {
+  firebaseAuth: Auth | null;
+}
+
+// SignOutButton Props
+export type SignOutButtonProps = {
+  firebaseAuth: Auth | null;
+}
+
+// StyledFirebaseAuth Props
+export type StyledFirebaseAuthProps = {
+  firebaseAuth: Auth | null;
+}
+
+// Footer Props
+export type FooterProps = {
+  loggedInUserName: string;
+}
+
+// WelcomeMessage Props (GoogleUserと同じなので、GoogleUserを使う)

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -110,7 +110,9 @@ export type StyledFirebaseAuthProps = {
 
 // Footer Props
 export type FooterProps = {
-  loggedInUserName: string;
+  isSignedIn: boolean;
+  user: GoogleUser;
+  firebaseAuth: Auth | null;
 }
 
 // WelcomeMessage Props (GoogleUserと同じなので、GoogleUserを使う)

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,7 +1,7 @@
 // コンポーネントのProps型定義をまとめたファイル
 
 import { Auth } from 'firebase/auth';
-import { AutocompleteChangeReason, AutocompleteChangeDetails } from '@mui/material';
+import { AutocompleteProps } from '@mui/material/Autocomplete';
 import { GoogleUser, InputChangeHandler, TextAreaChangeHandler } from './index';
 
 // Body Component Props
@@ -74,18 +74,16 @@ export type EsaTextFieldProps = {
   onChange: TextAreaChangeHandler;
 }
 
+// Autocomplete用の型エイリアス
+type AutocompleteChangeHandler<T> = AutocompleteProps<T, true, false, true>['onChange'];
+
 // EsaTagsField Props
 export type EsaTagsFieldProps = {
   fetching: boolean;
   sending: boolean;
   tags: string[];
   tagCandidates: string[];
-  onChange: (
-    event: React.SyntheticEvent,
-    value: string[],
-    reason: AutocompleteChangeReason,
-    detail?: AutocompleteChangeDetails<string>
-  ) => void;
+  onChange: AutocompleteChangeHandler<string>;
 }
 
 // TimesEsa Props

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -2,7 +2,7 @@
 
 import { Auth } from 'firebase/auth';
 import { AutocompleteChangeReason, AutocompleteChangeDetails } from '@mui/material';
-import { GoogleUser } from './index';
+import { GoogleUser, InputChangeHandler, TextAreaChangeHandler } from './index';
 
 // Body Component Props
 export type BodyProps = {
@@ -64,14 +64,14 @@ export type EsaTitleFieldProps = {
   fetching: boolean;
   sending: boolean;
   title: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: InputChangeHandler;
 }
 
 // EsaTextField Props
 export type EsaTextFieldProps = {
   sending: boolean;
   text: string;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onChange: TextAreaChangeHandler;
 }
 
 // EsaTagsField Props

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,3 +19,7 @@ export enum DailyReportType {
   TEXT = 'TEXT',
   SHARE = 'SHARE',
 }
+
+// Form要素のイベントハンドラー型
+export type InputChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => void;
+export type TextAreaChangeHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,21 @@
+// 共通の型定義をまとめたファイル
+
+// ユーザー情報の型定義
+export type GoogleUser = {
+  email: string;
+  displayName: string;
+  photoURL: string;
+}
+
+// タグの型定義
+export type Tag = {
+  name: string;
+  posts_count: number;
+}
+
+// 日報表示タイプのenum
+export enum DailyReportType {
+  HTML = 'HTML',
+  TEXT = 'TEXT',
+  SHARE = 'SHARE',
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,11 +20,6 @@ export const makeDefaultEsaCategory = (date: Date): string => {
 
 export const functionsRegion = 'asia-northeast1';
 
-export type GoogleUser = {
-  email: string;
-  displayName: string;
-  photoURL: string;
-}
 
 export const isValidEmail = (email: string): boolean => {
   return email === import.meta.env.VITE_VALID_MAIL_ADDRESSES;


### PR DESCRIPTION
## 概要

フロントエンドの型定義が各コンポーネントファイルに散らばっていたため、新しく`src/types`ディレクトリを作成して一元管理するように整理しました。

## 背景

- 型定義が各コンポーネントファイルに分散していて、再利用や管理が困難だった
- 共通で使える型（`GoogleUser`、`Tag`など）が個別のファイルに定義されていた
- 型定義の重複や不整合が起きやすい状態だった

## 変更内容

### 1. 型定義ファイルの新規作成
- `src/types/index.ts`: 共通型定義（`GoogleUser`、`Tag`、`DailyReportType`など）
- `src/types/components.ts`: コンポーネントのProps型定義を集約

### 2. 型定義の移動
- `GoogleUser`型: `src/util.ts` → `src/types/index.ts`
- `Tag`型: `src/components/TimesEsa/index.tsx` → `src/types/index.ts` 
- `DailyReportType` enum: `src/components/DailyReport/index.tsx` → `src/types/index.ts`
- 全コンポーネントのProps型: 各コンポーネントファイル → `src/types/components.ts`

### 3. 改善・最適化
- コンポーネントからの不要な型再エクスポートを削除
- Form要素のイベントハンドラー型を共通化（`InputChangeHandler`、`TextAreaChangeHandler`）
- AutocompleteのonChange型定義を簡略化（MUIの型を活用）
- 不要なコメントを削除

## テスト

- TypeScriptの型チェック: ✅ エラーなし
- 全テスト実行: ✅ 18テストがパス

## 効果

- 型定義の管理が一元化され、保守性が向上
- 型の再利用性が向上
- コードの可読性が改善
- 型定義の重複を防止