### PR TITLE
feat(backend): esa APIレスポンスのスネークケースからキャメルケースへの変換機能を追加

### DIFF
--- a/functions/src/__tests__/index.test.ts
+++ b/functions/src/__tests__/index.test.ts
@@ -794,7 +794,7 @@ describe('Firebase Functions Tests', () => {
       };
 
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         recentDailyReports.run(invalidContext)
       ).rejects.toThrow(new functions.https.HttpsError('permission-denied', 'Auth Error'));
     });
@@ -808,7 +808,7 @@ describe('Firebase Functions Tests', () => {
       };
 
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         recentDailyReports.run(noAuthContext)
       ).rejects.toThrow(new functions.https.HttpsError('permission-denied', 'Auth Error'));
     });
@@ -835,7 +835,7 @@ describe('Firebase Functions Tests', () => {
 
       const { recentDailyReports } = await import('../index');
       
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       const result = await recentDailyReports.run(mockContext);
 
       expect(mockGetRecentDailyReports).toHaveBeenCalledWith(10); // デフォルト値
@@ -860,7 +860,7 @@ describe('Firebase Functions Tests', () => {
         data: { days: 20 },
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       await recentDailyReports.run(contextWithDays);
 
       expect(mockGetRecentDailyReports).toHaveBeenCalledWith(20);
@@ -877,7 +877,7 @@ describe('Firebase Functions Tests', () => {
       };
 
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         recentDailyReports.run(contextWithZeroDays)
       ).rejects.toThrow(new functions.https.HttpsError('invalid-argument', 'daysパラメータは1から31の範囲で指定してください'));
       
@@ -888,7 +888,7 @@ describe('Firebase Functions Tests', () => {
       };
       
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         recentDailyReports.run(contextWithNegativeDays)
       ).rejects.toThrow(new functions.https.HttpsError('invalid-argument', 'daysパラメータは1から31の範囲で指定してください'));
     });
@@ -904,7 +904,7 @@ describe('Firebase Functions Tests', () => {
       };
 
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         recentDailyReports.run(contextWithLargeDays)
       ).rejects.toThrow(new functions.https.HttpsError('invalid-argument', 'daysパラメータは1から31の範囲で指定してください'));
       
@@ -915,7 +915,7 @@ describe('Firebase Functions Tests', () => {
       };
       
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         recentDailyReports.run(contextWithVeryLargeDays)
       ).rejects.toThrow(new functions.https.HttpsError('invalid-argument', 'daysパラメータは1から31の範囲で指定してください'));
     });
@@ -930,7 +930,7 @@ describe('Firebase Functions Tests', () => {
       const { recentDailyReports } = await import('../index');
       
       await expect(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+         
         recentDailyReports.run(mockContext)
       ).rejects.toThrow(new functions.https.HttpsError('internal', '日報リストの取得中にエラーが発生しました'));
     });

--- a/functions/src/__tests__/index.test.ts
+++ b/functions/src/__tests__/index.test.ts
@@ -6,7 +6,8 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 vi.mock('axios');
 
 // Import the functions to test
-import { transformTitle, checkAuthTokenEmail, getDailyReport, createOrUpdatePost, getTagList, type EsaSearchResult, type EsaPost, type EsaTags, type RecentDailyReportsRequest } from '../index';
+import { transformTitle, checkAuthTokenEmail, getDailyReport, createOrUpdatePost, getTagList, type EsaSearchResult, type RecentDailyReportsRequest } from '../index';
+import { type EsaPost, type EsaTags } from '../caseConverter';
 import { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 

--- a/functions/src/__tests__/index.test.ts
+++ b/functions/src/__tests__/index.test.ts
@@ -6,8 +6,9 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 vi.mock('axios');
 
 // Import the functions to test
-import { transformTitle, checkAuthTokenEmail, getDailyReport, createOrUpdatePost, getTagList, type EsaSearchResult, type RecentDailyReportsRequest } from '../index';
-import { type EsaPost, type EsaTags } from '../caseConverter';
+import { transformTitle, checkAuthTokenEmail, getDailyReport, createOrUpdatePost, getTagList } from '../index';
+import { type EsaPost, type EsaTags, type EsaSearchResult } from '../caseConverter';
+import { type RecentDailyReportsRequest } from '../types';
 import { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 

--- a/functions/src/__tests__/recentDailyReports.test.ts
+++ b/functions/src/__tests__/recentDailyReports.test.ts
@@ -5,7 +5,7 @@ import {
   getRecentDailyReports 
 } from '../recentDailyReports';
 import * as search from '../search';
-import type { EsaPost } from '../index';
+import type { EsaPost } from '../caseConverter';
 
 // searchPostsをモック
 vi.mock('../search');

--- a/functions/src/__tests__/search.test.ts
+++ b/functions/src/__tests__/search.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { searchPosts, searchDailyReport } from '../search';
 import { type SearchOption } from '../searchOptions';
 import type { AxiosInstance } from 'axios';
-import type { EsaSearchResult } from '../index';
+import type { EsaSearchResult } from '../caseConverter';
 
 // モック用のAxiosクライアント
 const mockGet = vi.fn();

--- a/functions/src/caseConverter.test.ts
+++ b/functions/src/caseConverter.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { convertEsaPostToCamelCase, convertEsaTagsToCamelCase } from './caseConverter';
+
+describe('convertEsaPostToCamelCase', () => {
+  it('Esa投稿のレスポンスを変換する', () => {
+    const input = {
+      body_md: '# Title\nContent',
+      body_html: '<h1>Title</h1><p>Content</p>',
+      updated_at: '2024-01-01T00:00:00Z',
+      number: 123,
+      name: 'Daily Report',
+      tags: ['javascript', 'typescript'],
+      url: 'https://esa.io/posts/123',
+      category: '日報/2024/01/01'
+    };
+    const expected = {
+      bodyMd: '# Title\nContent',
+      bodyHtml: '<h1>Title</h1><p>Content</p>',
+      updatedAt: '2024-01-01T00:00:00Z',
+      number: 123,
+      name: 'Daily Report',
+      tags: ['javascript', 'typescript'],
+      url: 'https://esa.io/posts/123',
+      category: '日報/2024/01/01'
+    };
+    expect(convertEsaPostToCamelCase(input)).toEqual(expected);
+  });
+
+  it('オプショナルなフィールドがない場合も正しく処理される', () => {
+    const input = {
+      body_md: 'Content',
+      body_html: '<p>Content</p>',
+      number: 123,
+      name: 'Title',
+      tags: []
+    };
+    const expected = {
+      bodyMd: 'Content',
+      bodyHtml: '<p>Content</p>',
+      number: 123,
+      name: 'Title',
+      tags: []
+    };
+    expect(convertEsaPostToCamelCase(input)).toEqual(expected);
+  });
+
+  it('タグ名にアンダースコアが含まれていても変換されない', () => {
+    const input = {
+      body_md: 'Content',
+      body_html: '<p>Content</p>',
+      number: 123,
+      name: 'Title',
+      tags: ['snake_case_tag', 'another_snake_tag']
+    };
+    const result = convertEsaPostToCamelCase(input);
+    expect(result.tags).toEqual(['snake_case_tag', 'another_snake_tag']);
+  });
+
+  it('未知のフィールドも変換される', () => {
+    const input = {
+      body_md: 'Content',
+      body_html: '<p>Content</p>',
+      number: 123,
+      name: 'Title',
+      tags: [],
+      custom_field: 'value',
+      another_custom: 'test'
+    };
+    const result = convertEsaPostToCamelCase(input);
+    expect(result.customField).toBe('value');
+    expect(result.anotherCustom).toBe('test');
+  });
+});
+
+describe('convertEsaTagsToCamelCase', () => {
+  it('Esaタグリストのレスポンスを変換する', () => {
+    const input = {
+      tags: [
+        { name: 'javascript', posts_count: 20 },
+        { name: 'typescript', posts_count: 15 },
+        { name: 'react', posts_count: 10 }
+      ],
+      total_count: 3
+    };
+    const expected = {
+      tags: [
+        { name: 'javascript', postsCount: 20 },
+        { name: 'typescript', postsCount: 15 },
+        { name: 'react', postsCount: 10 }
+      ],
+      totalCount: 3
+    };
+    expect(convertEsaTagsToCamelCase(input)).toEqual(expected);
+  });
+
+  it('タグ名にアンダースコアが含まれていても変換されない', () => {
+    const input = {
+      tags: [
+        { name: 'snake_case_tag', posts_count: 5 },
+        { name: 'another_snake_tag', posts_count: 3 }
+      ]
+    };
+    const result = convertEsaTagsToCamelCase(input);
+    expect(result.tags[0].name).toBe('snake_case_tag');
+    expect(result.tags[1].name).toBe('another_snake_tag');
+  });
+
+  it('total_countがない場合も正しく処理される', () => {
+    const input = {
+      tags: [
+        { name: 'tag1', posts_count: 10 }
+      ]
+    };
+    const expected = {
+      tags: [
+        { name: 'tag1', postsCount: 10 }
+      ]
+    };
+    expect(convertEsaTagsToCamelCase(input)).toEqual(expected);
+  });
+});

--- a/functions/src/caseConverter.test.ts
+++ b/functions/src/caseConverter.test.ts
@@ -26,23 +26,6 @@ describe('convertEsaPostToCamelCase', () => {
     expect(convertEsaPostToCamelCase(input)).toEqual(expected);
   });
 
-  it('オプショナルなフィールドがない場合も正しく処理される', () => {
-    const input = {
-      body_md: 'Content',
-      body_html: '<p>Content</p>',
-      number: 123,
-      name: 'Title',
-      tags: []
-    };
-    const expected = {
-      bodyMd: 'Content',
-      bodyHtml: '<p>Content</p>',
-      number: 123,
-      name: 'Title',
-      tags: []
-    };
-    expect(convertEsaPostToCamelCase(input)).toEqual(expected);
-  });
 
   it('タグ名にアンダースコアが含まれていても変換されない', () => {
     const input = {
@@ -50,7 +33,10 @@ describe('convertEsaPostToCamelCase', () => {
       body_html: '<p>Content</p>',
       number: 123,
       name: 'Title',
-      tags: ['snake_case_tag', 'another_snake_tag']
+      tags: ['snake_case_tag', 'another_snake_tag'],
+      updated_at: '2024-01-01T00:00:00Z',
+      url: 'https://esa.io/posts/123',
+      category: '日報/2024/01/01'
     };
     const result = convertEsaPostToCamelCase(input);
     expect(result.tags).toEqual(['snake_case_tag', 'another_snake_tag']);

--- a/functions/src/caseConverter.test.ts
+++ b/functions/src/caseConverter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { convertEsaPostToCamelCase, convertEsaTagsToCamelCase } from './caseConverter';
+import { 
+  convertEsaPostToCamelCase, 
+  convertEsaTagsToCamelCase,
+  convertDailyReportSummaryToCamelCase,
+  convertRecentDailyReportsResponseToCamelCase
+} from './caseConverter';
 
 describe('convertEsaPostToCamelCase', () => {
   it('Esa投稿のレスポンスを変換する', () => {
@@ -78,4 +83,68 @@ describe('convertEsaTagsToCamelCase', () => {
     expect(result.tags[1].name).toBe('another_snake_tag');
   });
 
+});
+
+describe('convertDailyReportSummaryToCamelCase', () => {
+  it('日報サマリーをキャメルケースに変換する', () => {
+    const input = {
+      date: '2024-01-01',
+      title: '日報',
+      category: '日報/2024/01/01',
+      updated_at: '2024-01-01T12:00:00Z',
+      number: 123
+    };
+    const expected = {
+      date: '2024-01-01',
+      title: '日報',
+      category: '日報/2024/01/01',
+      updatedAt: '2024-01-01T12:00:00Z',
+      number: 123
+    };
+    expect(convertDailyReportSummaryToCamelCase(input)).toEqual(expected);
+  });
+});
+
+describe('convertRecentDailyReportsResponseToCamelCase', () => {
+  it('最近の日報リストレスポンスを変換する', () => {
+    const input = {
+      reports: [
+        {
+          date: '2024-01-01',
+          title: '日報',
+          category: '日報/2024/01/01',
+          updated_at: '2024-01-01T12:00:00Z',
+          number: 123
+        },
+        {
+          date: '2024-01-02',
+          title: '開発、ミーティング',
+          category: '日報/2024/01/02',
+          updated_at: '2024-01-02T12:00:00Z',
+          number: 124
+        }
+      ],
+      total_count: 2
+    };
+    const expected = {
+      reports: [
+        {
+          date: '2024-01-01',
+          title: '日報',
+          category: '日報/2024/01/01',
+          updatedAt: '2024-01-01T12:00:00Z',
+          number: 123
+        },
+        {
+          date: '2024-01-02',
+          title: '開発、ミーティング',
+          category: '日報/2024/01/02',
+          updatedAt: '2024-01-02T12:00:00Z',
+          number: 124
+        }
+      ],
+      totalCount: 2
+    };
+    expect(convertRecentDailyReportsResponseToCamelCase(input)).toEqual(expected);
+  });
 });

--- a/functions/src/caseConverter.test.ts
+++ b/functions/src/caseConverter.test.ts
@@ -56,20 +56,6 @@ describe('convertEsaPostToCamelCase', () => {
     expect(result.tags).toEqual(['snake_case_tag', 'another_snake_tag']);
   });
 
-  it('未知のフィールドも変換される', () => {
-    const input = {
-      body_md: 'Content',
-      body_html: '<p>Content</p>',
-      number: 123,
-      name: 'Title',
-      tags: [],
-      custom_field: 'value',
-      another_custom: 'test'
-    };
-    const result = convertEsaPostToCamelCase(input);
-    expect(result.customField).toBe('value');
-    expect(result.anotherCustom).toBe('test');
-  });
 });
 
 describe('convertEsaTagsToCamelCase', () => {

--- a/functions/src/caseConverter.test.ts
+++ b/functions/src/caseConverter.test.ts
@@ -70,24 +70,12 @@ describe('convertEsaTagsToCamelCase', () => {
       tags: [
         { name: 'snake_case_tag', posts_count: 5 },
         { name: 'another_snake_tag', posts_count: 3 }
-      ]
+      ],
+      total_count: 2
     };
     const result = convertEsaTagsToCamelCase(input);
     expect(result.tags[0].name).toBe('snake_case_tag');
     expect(result.tags[1].name).toBe('another_snake_tag');
   });
 
-  it('total_countがない場合も正しく処理される', () => {
-    const input = {
-      tags: [
-        { name: 'tag1', posts_count: 10 }
-      ]
-    };
-    const expected = {
-      tags: [
-        { name: 'tag1', postsCount: 10 }
-      ]
-    };
-    expect(convertEsaTagsToCamelCase(input)).toEqual(expected);
-  });
 });

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -3,8 +3,8 @@
  * esa APIのレスポンス構造に特化
  */
 
-// EsaのAPI型定義（スネークケース）
-type EsaPostApi = {
+// esa APIからのレスポンス型定義（スネークケース）
+type EsaPostApiResponse = {
   body_md: string;
   body_html: string;
   number: number;
@@ -15,13 +15,13 @@ type EsaPostApi = {
   category: string;
 }
 
-type EsaTagApi = {
+type EsaTagApiResponse = {
   name: string;  // タグ名（変換不要）
   posts_count: number;
 }
 
-type EsaTagsApi = {
-  tags: EsaTagApi[];
+type EsaTagsApiResponse = {
+  tags: EsaTagApiResponse[];
   total_count?: number;
 }
 
@@ -51,7 +51,7 @@ type EsaTagsResponse = {
  * EsaのAPIレスポンス（投稿）をキャメルケースに変換
  * タグ名などの値は変換せず、フィールド名のみを変換
  */
-export function convertEsaPostToCamelCase(esaPost: EsaPostApi): EsaPostResponse {
+export function convertEsaPostToCamelCase(esaPost: EsaPostApiResponse): EsaPostResponse {
   return {
     bodyMd: esaPost.body_md,
     bodyHtml: esaPost.body_html,
@@ -68,7 +68,7 @@ export function convertEsaPostToCamelCase(esaPost: EsaPostApi): EsaPostResponse 
  * EsaのAPIレスポンス（タグリスト）をキャメルケースに変換
  * タグ名は変換せず、フィールド名のみを変換
  */
-export function convertEsaTagsToCamelCase(esaTags: EsaTagsApi): EsaTagsResponse {
+export function convertEsaTagsToCamelCase(esaTags: EsaTagsApiResponse): EsaTagsResponse {
   return {
     tags: esaTags.tags.map(tag => ({
       name: tag.name,  // タグ名はそのまま

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -26,7 +26,7 @@ export type EsaTags = {
 }
 
 // 変換後の型定義（キャメルケース、フロントエンドで使用）
-type EsaPostCamelCase = {
+export type EsaPostCamelCase = {
   bodyMd: string;
   bodyHtml: string;
   number: number;
@@ -37,12 +37,12 @@ type EsaPostCamelCase = {
   category: string;
 }
 
-type EsaTagCamelCase = {
+export type EsaTagCamelCase = {
   name: string;  // タグ名はそのまま保持
   postsCount: number;
 }
 
-type EsaTagsCamelCase = {
+export type EsaTagsCamelCase = {
   tags: EsaTagCamelCase[];
   totalCount: number;
 }

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -25,8 +25,8 @@ type EsaTagsApiResponse = {
   total_count?: number;
 }
 
-// 変換後の型定義（キャメルケース）
-type EsaPostResponse = {
+// 変換後の型定義（キャメルケース、フロントエンドで使用）
+type EsaPostCamelCase = {
   bodyMd: string;
   bodyHtml: string;
   number: number;
@@ -37,13 +37,13 @@ type EsaPostResponse = {
   category: string;
 }
 
-type EsaTagResponse = {
+type EsaTagCamelCase = {
   name: string;  // タグ名はそのまま保持
   postsCount: number;
 }
 
-type EsaTagsResponse = {
-  tags: EsaTagResponse[];
+type EsaTagsCamelCase = {
+  tags: EsaTagCamelCase[];
   totalCount?: number;
 }
 
@@ -51,7 +51,7 @@ type EsaTagsResponse = {
  * EsaのAPIレスポンス（投稿）をキャメルケースに変換
  * タグ名などの値は変換せず、フィールド名のみを変換
  */
-export function convertEsaPostToCamelCase(esaPost: EsaPostApiResponse): EsaPostResponse {
+export function convertEsaPostToCamelCase(esaPost: EsaPostApiResponse): EsaPostCamelCase {
   return {
     bodyMd: esaPost.body_md,
     bodyHtml: esaPost.body_html,
@@ -68,7 +68,7 @@ export function convertEsaPostToCamelCase(esaPost: EsaPostApiResponse): EsaPostR
  * EsaのAPIレスポンス（タグリスト）をキャメルケースに変換
  * タグ名は変換せず、フィールド名のみを変換
  */
-export function convertEsaTagsToCamelCase(esaTags: EsaTagsApiResponse): EsaTagsResponse {
+export function convertEsaTagsToCamelCase(esaTags: EsaTagsApiResponse): EsaTagsCamelCase {
   return {
     tags: esaTags.tags.map(tag => ({
       name: tag.name,  // タグ名はそのまま

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -3,6 +3,8 @@
  * esa APIのレスポンス構造に特化
  */
 
+import { type DateString, type DailyReportCategory } from './dateUtils';
+
 // esa APIからのレスポンス型定義（スネークケース）
 export type EsaPost = {
   body_md: string;
@@ -75,5 +77,56 @@ export function convertEsaTagsToCamelCase(esaTags: EsaTags): EsaTagsCamelCase {
       postsCount: tag.posts_count
     })),
     totalCount: esaTags.total_count
+  };
+}
+
+// 日報サマリー関連の型定義（スネークケース）
+export type DailyReportSummary = {
+  date: DateString;
+  title: string;
+  category: DailyReportCategory;
+  updated_at: string;
+  number: number;
+}
+
+export type RecentDailyReportsResponse = {
+  reports: DailyReportSummary[];
+  total_count: number;
+}
+
+// 日報サマリー関連の型定義（キャメルケース）
+export type DailyReportSummaryCamelCase = {
+  date: DateString;
+  title: string;
+  category: DailyReportCategory;
+  updatedAt: string;
+  number: number;
+}
+
+export type RecentDailyReportsResponseCamelCase = {
+  reports: DailyReportSummaryCamelCase[];
+  totalCount: number;
+}
+
+/**
+ * 日報サマリーをキャメルケースに変換
+ */
+export function convertDailyReportSummaryToCamelCase(summary: DailyReportSummary): DailyReportSummaryCamelCase {
+  return {
+    date: summary.date,
+    title: summary.title,
+    category: summary.category,
+    updatedAt: summary.updated_at,
+    number: summary.number
+  };
+}
+
+/**
+ * 最近の日報リストレスポンスをキャメルケースに変換
+ */
+export function convertRecentDailyReportsResponseToCamelCase(response: RecentDailyReportsResponse): RecentDailyReportsResponseCamelCase {
+  return {
+    reports: response.reports.map(report => convertDailyReportSummaryToCamelCase(report)),
+    totalCount: response.total_count
   };
 }

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -10,9 +10,9 @@ type EsaPostApi = {
   number: number;
   name: string;
   tags: string[];  // タグ名の文字列配列（変換不要）
-  updated_at?: string;
-  url?: string;
-  category?: string;
+  updated_at: string;
+  url: string;
+  category: string;
 }
 
 type EsaTagApi = {
@@ -32,9 +32,9 @@ type EsaPostResponse = {
   number: number;
   name: string;
   tags: string[];  // タグ名はそのまま保持
-  updatedAt?: string;
-  url?: string;
-  category?: string;
+  updatedAt: string;
+  url: string;
+  category: string;
 }
 
 type EsaTagResponse = {
@@ -58,9 +58,9 @@ export function convertEsaPostToCamelCase(esaPost: EsaPostApi): EsaPostResponse 
     number: esaPost.number,
     name: esaPost.name,
     tags: esaPost.tags,  // タグ名の配列はそのまま
-    ...(esaPost.updated_at !== undefined && { updatedAt: esaPost.updated_at }),
-    ...(esaPost.url !== undefined && { url: esaPost.url }),
-    ...(esaPost.category !== undefined && { category: esaPost.category })
+    updatedAt: esaPost.updated_at,
+    url: esaPost.url,
+    category: esaPost.category
   };
 }
 

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -3,14 +3,6 @@
  * esa APIのレスポンス構造に特化
  */
 
-/**
- * スネークケースの文字列をキャメルケースに変換
- * @example "body_md" -> "bodyMd"
- */
-function snakeToCamel(str: string): string {
-  return str.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
-}
-
 // EsaのAPI型定義（スネークケース）
 type EsaPostApi = {
   body_md: string;
@@ -21,7 +13,6 @@ type EsaPostApi = {
   updated_at?: string;
   url?: string;
   category?: string;
-  [key: string]: unknown;
 }
 
 type EsaTagApi = {
@@ -44,7 +35,6 @@ type EsaPostResponse = {
   updatedAt?: string;
   url?: string;
   category?: string;
-  [key: string]: unknown;
 }
 
 type EsaTagResponse = {
@@ -70,14 +60,7 @@ export function convertEsaPostToCamelCase(esaPost: EsaPostApi): EsaPostResponse 
     tags: esaPost.tags,  // タグ名の配列はそのまま
     ...(esaPost.updated_at !== undefined && { updatedAt: esaPost.updated_at }),
     ...(esaPost.url !== undefined && { url: esaPost.url }),
-    ...(esaPost.category !== undefined && { category: esaPost.category }),
-    // その他の未知のフィールドも変換
-    ...Object.keys(esaPost)
-      .filter(key => !['body_md', 'body_html', 'number', 'name', 'tags', 'updated_at', 'url', 'category'].includes(key))
-      .reduce((acc, key) => ({
-        ...acc,
-        [snakeToCamel(key)]: esaPost[key]
-      }), {})
+    ...(esaPost.category !== undefined && { category: esaPost.category })
   };
 }
 

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -22,7 +22,7 @@ export type Tag = {
 
 export type EsaTags = {
   tags: Tag[];
-  total_count?: number;
+  total_count: number;
 }
 
 // 変換後の型定義（キャメルケース、フロントエンドで使用）
@@ -44,7 +44,7 @@ type EsaTagCamelCase = {
 
 type EsaTagsCamelCase = {
   tags: EsaTagCamelCase[];
-  totalCount?: number;
+  totalCount: number;
 }
 
 /**
@@ -74,6 +74,6 @@ export function convertEsaTagsToCamelCase(esaTags: EsaTags): EsaTagsCamelCase {
       name: tag.name,  // タグ名はそのまま
       postsCount: tag.posts_count
     })),
-    ...(esaTags.total_count !== undefined && { totalCount: esaTags.total_count })
+    totalCount: esaTags.total_count
   };
 }

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -1,0 +1,54 @@
+/**
+ * スネークケースからキャメルケースへの変換ユーティリティ
+ */
+
+/**
+ * スネークケースの文字列をキャメルケースに変換
+ * @example "body_md" -> "bodyMd"
+ */
+export function snakeToCamel(str: string): string {
+  return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+/**
+ * オブジェクトのキーをスネークケースからキャメルケースに変換
+ * ネストされたオブジェクトや配列にも対応
+ */
+export function convertKeysToCamelCase<T = any>(obj: any): T {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => convertKeysToCamelCase(item)) as any;
+  }
+
+  if (obj instanceof Date || typeof obj !== 'object') {
+    return obj;
+  }
+
+  const converted: any = {};
+  
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      const camelKey = snakeToCamel(key);
+      converted[camelKey] = convertKeysToCamelCase(obj[key]);
+    }
+  }
+
+  return converted;
+}
+
+/**
+ * EsaのAPIレスポンス（投稿）をキャメルケースに変換
+ */
+export function convertEsaPostToCamelCase(esaPost: any): any {
+  return convertKeysToCamelCase(esaPost);
+}
+
+/**
+ * EsaのAPIレスポンス（タグリスト）をキャメルケースに変換
+ */
+export function convertEsaTagsToCamelCase(esaTags: any): any {
+  return convertKeysToCamelCase(esaTags);
+}

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -12,7 +12,7 @@ function snakeToCamel(str: string): string {
 }
 
 // EsaのAPI型定義（スネークケース）
-interface EsaPostApi {
+type EsaPostApi = {
   body_md: string;
   body_html: string;
   number: number;
@@ -24,18 +24,18 @@ interface EsaPostApi {
   [key: string]: unknown;
 }
 
-interface EsaTagApi {
+type EsaTagApi = {
   name: string;  // タグ名（変換不要）
   posts_count: number;
 }
 
-interface EsaTagsApi {
+type EsaTagsApi = {
   tags: EsaTagApi[];
   total_count?: number;
 }
 
 // 変換後の型定義（キャメルケース）
-interface EsaPostResponse {
+type EsaPostResponse = {
   bodyMd: string;
   bodyHtml: string;
   number: number;
@@ -47,12 +47,12 @@ interface EsaPostResponse {
   [key: string]: unknown;
 }
 
-interface EsaTagResponse {
+type EsaTagResponse = {
   name: string;  // タグ名はそのまま保持
   postsCount: number;
 }
 
-interface EsaTagsResponse {
+type EsaTagsResponse = {
   tags: EsaTagResponse[];
   totalCount?: number;
 }

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -27,6 +27,11 @@ export type EsaTags = {
   total_count: number;
 }
 
+export type EsaSearchResult = {
+  posts: EsaPost[];
+  total_count: number;
+}
+
 // 変換後の型定義（キャメルケース、フロントエンドで使用）
 export type EsaPostCamelCase = {
   bodyMd: string;

--- a/functions/src/caseConverter.ts
+++ b/functions/src/caseConverter.ts
@@ -4,7 +4,7 @@
  */
 
 // esa APIからのレスポンス型定義（スネークケース）
-type EsaPostApiResponse = {
+export type EsaPost = {
   body_md: string;
   body_html: string;
   number: number;
@@ -15,13 +15,13 @@ type EsaPostApiResponse = {
   category: string;
 }
 
-type EsaTagApiResponse = {
+export type Tag = {
   name: string;  // タグ名（変換不要）
   posts_count: number;
 }
 
-type EsaTagsApiResponse = {
-  tags: EsaTagApiResponse[];
+export type EsaTags = {
+  tags: Tag[];
   total_count?: number;
 }
 
@@ -51,7 +51,7 @@ type EsaTagsCamelCase = {
  * EsaのAPIレスポンス（投稿）をキャメルケースに変換
  * タグ名などの値は変換せず、フィールド名のみを変換
  */
-export function convertEsaPostToCamelCase(esaPost: EsaPostApiResponse): EsaPostCamelCase {
+export function convertEsaPostToCamelCase(esaPost: EsaPost): EsaPostCamelCase {
   return {
     bodyMd: esaPost.body_md,
     bodyHtml: esaPost.body_html,
@@ -68,7 +68,7 @@ export function convertEsaPostToCamelCase(esaPost: EsaPostApiResponse): EsaPostC
  * EsaのAPIレスポンス（タグリスト）をキャメルケースに変換
  * タグ名は変換せず、フィールド名のみを変換
  */
-export function convertEsaTagsToCamelCase(esaTags: EsaTagsApiResponse): EsaTagsCamelCase {
+export function convertEsaTagsToCamelCase(esaTags: EsaTags): EsaTagsCamelCase {
   return {
     tags: esaTags.tags.map(tag => ({
       name: tag.name,  // タグ名はそのまま

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -46,6 +46,9 @@ export type EsaPost = {
   number: number;
   name: string;
   tags: string[];
+  updated_at: string;
+  url: string;
+  category: string;
 }
 
 type TimesEsaPostRequest = {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,21 +6,23 @@ import { CallableRequest, onCall } from 'firebase-functions/v2/https';
 import { searchDailyReport } from './search';
 import { formatCategoryToDate, type DailyReportCategory, type DateString } from './dateUtils';
 import { 
+  type EsaConfig,
+  type SubmitTextRequest, 
+  type DailyReportRequest, 
+  type RecentDailyReportsRequest, 
+  type EsaErrorResponse 
+} from './types';
+import { 
   convertEsaPostToCamelCase, 
   convertEsaTagsToCamelCase, 
   convertRecentDailyReportsResponseToCamelCase,
-  EsaPost, 
-  EsaTags,
-  type DailyReportSummary,
-  type RecentDailyReportsResponse 
+  type EsaPost, 
+  type EsaTags,
+  type EsaSearchResult 
 } from './caseConverter';
 
 setGlobalOptions({ region: 'asia-northeast1' })
 
-type EsaConfig = {
-  teamName: string;
-  accessToken: string;
-}
 
 const ESA_SECRETS = [
   "ESA_TEAM_NAME",
@@ -47,23 +49,8 @@ export function createAxiosClient(accessToken?: string): AxiosInstance {
   });
 }
 
-type SubmitTextRequest = {
-  category: DailyReportCategory;
-  tags: string[];
-  title: string;
-  text: string;
-}
 
-export type EsaSearchResult = {
-  posts: EsaPost[];
-  total_count: number;
-}
 
-// ref: https://docs.esa.io/posts/102#%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9
-type EsaErrorResponse = {
-  error: string;
-  message: string;
-}
 
 /**
  * 複数のセッションから並行編集されたタイトルをマージする
@@ -218,13 +205,7 @@ export const submitTextToEsa = onCall(
   }
 );
 
-type DailyReportRequest = {
-  category: DailyReportCategory;
-}
 
-type RecentDailyReportsRequest = {
-  days?: number; // 過去何日分を取得するか（デフォルト: 10）
-}
 
 
 export const dailyReport = onCall(

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,6 +5,7 @@ import { setGlobalOptions } from 'firebase-functions/v2'
 import { CallableRequest, onCall } from 'firebase-functions/v2/https';
 import { searchDailyReport } from './search';
 import { formatCategoryToDate, type DailyReportCategory, type DateString } from './dateUtils';
+import { convertEsaPostToCamelCase, convertEsaTagsToCamelCase } from './caseConverter';
 
 setGlobalOptions({ region: 'asia-northeast1' })
 
@@ -223,7 +224,8 @@ export const submitTextToEsa = onCall(
       req.data.title,
       req.data.text,
     );
-    return result;
+    // スネークケースからキャメルケースに変換して返す
+    return convertEsaPostToCamelCase(result);
   }
 );
 
@@ -258,7 +260,8 @@ export const dailyReport = onCall(
     const esaConfig = getEsaConfig();
     const axios = createAxiosClient(esaConfig.accessToken);
     const result = await getDailyReport(axios, esaConfig, req.data.category);
-    return result;
+    // スネークケースからキャメルケースに変換して返す
+    return convertEsaPostToCamelCase(result);
   }
 );
 
@@ -272,7 +275,8 @@ export const tagList = onCall(
     const esaConfig = getEsaConfig();
     const axios = createAxiosClient(esaConfig.accessToken);
     const result = await getTagList(axios, esaConfig);
-    return result;
+    // スネークケースからキャメルケースに変換して返す
+    return convertEsaTagsToCamelCase(result);
   }
 );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -206,7 +206,6 @@ export const submitTextToEsa = onCall(
       req.data.title,
       req.data.text,
     );
-    // スネークケースからキャメルケースに変換して返す
     return convertEsaPostToCamelCase(result);
   }
 );
@@ -242,7 +241,6 @@ export const dailyReport = onCall(
     const esaConfig = getEsaConfig();
     const axios = createAxiosClient(esaConfig.accessToken);
     const result = await getDailyReport(axios, esaConfig, req.data.category);
-    // スネークケースからキャメルケースに変換して返す
     return convertEsaPostToCamelCase(result);
   }
 );
@@ -257,7 +255,6 @@ export const tagList = onCall(
     const esaConfig = getEsaConfig();
     const axios = createAxiosClient(esaConfig.accessToken);
     const result = await getTagList(axios, esaConfig);
-    // スネークケースからキャメルケースに変換して返す
     return convertEsaTagsToCamelCase(result);
   }
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,7 +5,7 @@ import { setGlobalOptions } from 'firebase-functions/v2'
 import { CallableRequest, onCall } from 'firebase-functions/v2/https';
 import { searchDailyReport } from './search';
 import { formatCategoryToDate, type DailyReportCategory, type DateString } from './dateUtils';
-import { convertEsaPostToCamelCase, convertEsaTagsToCamelCase } from './caseConverter';
+import { convertEsaPostToCamelCase, convertEsaTagsToCamelCase, EsaPost, EsaTags } from './caseConverter';
 
 setGlobalOptions({ region: 'asia-northeast1' })
 
@@ -39,18 +39,6 @@ export function createAxiosClient(accessToken?: string): AxiosInstance {
   });
 }
 
-export type EsaPost = {
-  // esaのレスポンスを全部camelcaseに変換するのは面倒なので、ここだけlintは無視する
-  body_md: string;
-  body_html: string;
-  number: number;
-  name: string;
-  tags: string[];
-  updated_at: string;
-  url: string;
-  category: string;
-}
-
 type TimesEsaPostRequest = {
   category: DailyReportCategory;
   tags: string[];
@@ -61,15 +49,6 @@ type TimesEsaPostRequest = {
 export type EsaSearchResult = {
   posts: EsaPost[];
   total_count: number;
-}
-
-export type Tag = {
-  name: string;
-  posts_count: number;
-}
-
-export type EsaTags = {
-  tags: Tag[]
 }
 
 // ref: https://docs.esa.io/posts/102#%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -226,9 +226,22 @@ export type DailyReportSummary = {
   number: number; // esa投稿番号
 }
 
+export type DailyReportSummaryCamelCase = {
+  date: DateString;
+  title: string;
+  category: DailyReportCategory;
+  updatedAt: string;
+  number: number;
+}
+
 export type RecentDailyReportsResponse = {
   reports: DailyReportSummary[];
   total_count: number;
+}
+
+export type RecentDailyReportsResponseCamelCase = {
+  reports: DailyReportSummaryCamelCase[];
+  totalCount: number;
 }
 
 export const dailyReport = onCall(
@@ -276,7 +289,17 @@ export const recentDailyReports = onCall(
     
     try {
       const result = await getRecentDailyReports(days);
-      return result;
+      // キャメルケースに変換
+      return {
+        reports: result.reports.map(report => ({
+          date: report.date,
+          title: report.title,
+          category: report.category,
+          updatedAt: report.updated_at,
+          number: report.number
+        })),
+        totalCount: result.total_count
+      };
     } catch (error) {
       console.error('recentDailyReports error:', error);
       throw new functions.https.HttpsError('internal', '日報リストの取得中にエラーが発生しました');

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -39,7 +39,7 @@ export function createAxiosClient(accessToken?: string): AxiosInstance {
   });
 }
 
-type TimesEsaPostRequest = {
+type SubmitTextRequest = {
   category: DailyReportCategory;
   tags: string[];
   title: string;
@@ -192,7 +192,7 @@ export function checkAuthTokenEmail(context: CallableRequest): void {
 export const submitTextToEsa = onCall(
   { secrets: ESA_SECRETS},
   async (
-    req: CallableRequest<TimesEsaPostRequest>,
+    req: CallableRequest<SubmitTextRequest>,
   ) => {
     checkAuthTokenEmail(req);
 
@@ -210,7 +210,7 @@ export const submitTextToEsa = onCall(
   }
 );
 
-type TimesEsaDailyReportRequest = {
+type DailyReportRequest = {
   category: DailyReportCategory;
 }
 
@@ -247,7 +247,7 @@ export type RecentDailyReportsResponseCamelCase = {
 export const dailyReport = onCall(
   { secrets: ESA_SECRETS},
   async (
-    req: CallableRequest<TimesEsaDailyReportRequest>,
+    req: CallableRequest<DailyReportRequest>,
   ) => {
     checkAuthTokenEmail(req);
 

--- a/functions/src/recentDailyReports.ts
+++ b/functions/src/recentDailyReports.ts
@@ -5,7 +5,8 @@
 import { AxiosInstance } from 'axios';
 import { searchPosts } from './search';
 import { getDateRangeCategories, formatCategoryToDate, isDailyReportCategory, type DailyReportCategory } from './dateUtils';
-import { type DailyReportSummary, type EsaPost } from './index';
+import { type DailyReportSummary } from './index';
+import { type EsaPost } from './caseConverter';
 
 /**
  * 複数の日報カテゴリをOR検索クエリとして結合する

--- a/functions/src/recentDailyReports.ts
+++ b/functions/src/recentDailyReports.ts
@@ -63,14 +63,11 @@ export async function getRecentDailyReports(
   
   // 結果を日報サマリー形式に変換
   const reports = result.posts
-    .filter((post: EsaPost) => {
+    .filter((post: EsaPost): post is EsaPost & { category: DailyReportCategory } => {
       // 念のため日報カテゴリのみをフィルタリング
       return isDailyReportCategory(post.category);
     })
-    .map((post: EsaPost) => extractDailyReportSummary({
-      ...post,
-      category: post.category as DailyReportCategory
-    }));
+    .map((post) => extractDailyReportSummary(post));
   
   return {
     reports,

--- a/functions/src/recentDailyReports.ts
+++ b/functions/src/recentDailyReports.ts
@@ -63,12 +63,14 @@ export async function getRecentDailyReports(
   
   // 結果を日報サマリー形式に変換
   const reports = result.posts
-    .filter(post => {
+    .filter((post: EsaPost) => {
       // 念のため日報カテゴリのみをフィルタリング
-      const postWithCategory = post as EsaPost & { category?: string };
-      return postWithCategory.category ? isDailyReportCategory(postWithCategory.category) : false;
+      return isDailyReportCategory(post.category);
     })
-    .map(post => extractDailyReportSummary(post as EsaPost & { category: DailyReportCategory; updated_at: string }));
+    .map((post: EsaPost) => extractDailyReportSummary({
+      ...post,
+      category: post.category as DailyReportCategory
+    }));
   
   return {
     reports,

--- a/functions/src/recentDailyReports.ts
+++ b/functions/src/recentDailyReports.ts
@@ -5,8 +5,7 @@
 import { AxiosInstance } from 'axios';
 import { searchPosts } from './search';
 import { getDateRangeCategories, formatCategoryToDate, isDailyReportCategory, type DailyReportCategory } from './dateUtils';
-import { type DailyReportSummary } from './index';
-import { type EsaPost } from './caseConverter';
+import { type EsaPost, type DailyReportSummary } from './caseConverter';
 
 /**
  * 複数の日報カテゴリをOR検索クエリとして結合する

--- a/functions/src/search.ts
+++ b/functions/src/search.ts
@@ -4,7 +4,8 @@
 
 import { AxiosInstance } from 'axios';
 import { SearchOption, combineOptions } from './searchOptions';
-import { createAxiosClient, getEsaConfig, type EsaSearchResult } from './index';
+import { createAxiosClient, getEsaConfig } from './index';
+import { type EsaSearchResult } from './caseConverter';
 
 /**
  * 検索パラメータの型定義

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Firebase Functionsのリクエスト/レスポンス型定義
+ */
+
+import { type DailyReportCategory } from './dateUtils';
+
+// 設定型定義
+export type EsaConfig = {
+  teamName: string;
+  accessToken: string;
+}
+
+// リクエスト型定義
+export type SubmitTextRequest = {
+  category: DailyReportCategory;
+  tags: string[];
+  title: string;
+  text: string;
+}
+
+export type DailyReportRequest = {
+  category: DailyReportCategory;
+}
+
+export type RecentDailyReportsRequest = {
+  days?: number; // 過去何日分を取得するか（デフォルト: 10）
+}
+
+// エラーレスポンス型定義
+export type EsaErrorResponse = {
+  error: string;
+  message: string;
+}

--- a/src/api/mockData.ts
+++ b/src/api/mockData.ts
@@ -75,31 +75,42 @@ export const mockTagListData = {
 export const mockRecentDailyReportsData = {
   reports: [
     {
-      date: format(new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
-      url: 'https://example.esa.io/posts/12344',
-      postsCount: 8,
+      date: format(new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), 'yyyy-MM-dd'),
+      title: '日報',
+      category: `日報/${format(new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd')}`,
+      updatedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      number: 12344,
     },
     {
-      date: format(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
-      url: 'https://example.esa.io/posts/12343',
-      postsCount: 12,
+      date: format(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), 'yyyy-MM-dd'),
+      title: '日報、開発',
+      category: `日報/${format(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd')}`,
+      updatedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      number: 12343,
     },
     {
-      date: format(new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
-      url: 'https://example.esa.io/posts/12342',
-      postsCount: 6,
+      date: format(new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), 'yyyy-MM-dd'),
+      title: 'ミーティング、レビュー',
+      category: `日報/${format(new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd')}`,
+      updatedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      number: 12342,
     },
     {
-      date: format(new Date(Date.now() - 4 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
-      url: 'https://example.esa.io/posts/12341',
-      postsCount: 10,
+      date: format(new Date(Date.now() - 4 * 24 * 60 * 60 * 1000), 'yyyy-MM-dd'),
+      title: '開発、タスクA',
+      category: `日報/${format(new Date(Date.now() - 4 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd')}`,
+      updatedAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+      number: 12341,
     },
     {
-      date: format(new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
-      url: 'https://example.esa.io/posts/12340',
-      postsCount: 7,
+      date: format(new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), 'yyyy-MM-dd'),
+      title: '日報',
+      category: `日報/${format(new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd')}`,
+      updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      number: 12340,
     },
   ],
+  totalCount: 5
 };
 
 // 投稿時のレスポンスモック（既存の日報に追記される想定）

--- a/src/api/mockData.ts
+++ b/src/api/mockData.ts
@@ -2,9 +2,9 @@ import { format } from 'date-fns';
 
 // 日報のモックデータ
 export const mockDailyReportData = {
-  updated_at: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
   url: 'https://example.esa.io/posts/12345',
-  body_md: `<a id="1000" href="#1000">10:00</a> 朝会に参加しました
+  bodyMd: `<a id="1000" href="#1000">10:00</a> 朝会に参加しました
 
 ---
 
@@ -28,7 +28,7 @@ export const mockDailyReportData = {
 
 ---
 `,
-  body_html: `<p><a id="1000" href="#1000">10:00</a> 朝会に参加しました</p>
+  bodyHtml: `<p><a id="1000" href="#1000">10:00</a> 朝会に参加しました</p>
 <hr>
 <p><a id="1030" href="#1030">10:30</a> タスクAの実装を開始</p>
 <hr>
@@ -54,20 +54,21 @@ export const mockDailyReportNotFoundError = {
 // タグ一覧のモックデータ
 export const mockTagListData = {
   tags: [
-    { name: '開発', posts_count: 156 },
-    { name: 'ミーティング', posts_count: 89 },
-    { name: 'レビュー', posts_count: 124 },
-    { name: 'タスクA', posts_count: 23 },
-    { name: 'タスクB', posts_count: 18 },
-    { name: 'リファクタリング', posts_count: 45 },
-    { name: '調査', posts_count: 67 },
-    { name: 'ドキュメント', posts_count: 34 },
-    { name: '月曜日', posts_count: 52 },
-    { name: '火曜日', posts_count: 51 },
-    { name: '水曜日', posts_count: 53 },
-    { name: '木曜日', posts_count: 50 },
-    { name: '金曜日', posts_count: 49 },
+    { name: '開発', postsCount: 156 },
+    { name: 'ミーティング', postsCount: 89 },
+    { name: 'レビュー', postsCount: 124 },
+    { name: 'タスクA', postsCount: 23 },
+    { name: 'タスクB', postsCount: 18 },
+    { name: 'リファクタリング', postsCount: 45 },
+    { name: '調査', postsCount: 67 },
+    { name: 'ドキュメント', postsCount: 34 },
+    { name: '月曜日', postsCount: 52 },
+    { name: '火曜日', postsCount: 51 },
+    { name: '水曜日', postsCount: 53 },
+    { name: '木曜日', postsCount: 50 },
+    { name: '金曜日', postsCount: 49 },
   ],
+  totalCount: 13
 };
 
 // 最近の日報一覧のモックデータ
@@ -76,42 +77,42 @@ export const mockRecentDailyReportsData = {
     {
       date: format(new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
       url: 'https://example.esa.io/posts/12344',
-      posts_count: 8,
+      postsCount: 8,
     },
     {
       date: format(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
       url: 'https://example.esa.io/posts/12343',
-      posts_count: 12,
+      postsCount: 12,
     },
     {
       date: format(new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
       url: 'https://example.esa.io/posts/12342',
-      posts_count: 6,
+      postsCount: 6,
     },
     {
       date: format(new Date(Date.now() - 4 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
       url: 'https://example.esa.io/posts/12341',
-      posts_count: 10,
+      postsCount: 10,
     },
     {
       date: format(new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), 'yyyy/MM/dd'),
       url: 'https://example.esa.io/posts/12340',
-      posts_count: 7,
+      postsCount: 7,
     },
   ],
 };
 
 // 投稿時のレスポンスモック（既存の日報に追記される想定）
 export const createSubmitResponse = (category: string, tags: string[], title: string, text: string) => {
-  const currentBody = mockDailyReportData.body_md;
+  const currentBody = mockDailyReportData.bodyMd;
   const newBodyMd = currentBody + text;
   const newBodyHtml = newBodyMd.replace(/\n/g, '<br>').replace(/---/g, '<hr>');
   
   return {
-    updated_at: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
     url: mockDailyReportData.url,
-    body_md: newBodyMd,
-    body_html: newBodyHtml,
+    bodyMd: newBodyMd,
+    bodyHtml: newBodyHtml,
     tags: [...new Set([...tags, ...mockDailyReportData.tags])], // 重複を除去
     name: title,
     category: category,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,10 +6,10 @@ export type DailyReportRequest = {
 }
 
 export type DailyReportResponse = {
-  updated_at: string;
+  updatedAt: string;
   url: string;
-  body_md: string;
-  body_html: string;
+  bodyMd: string;
+  bodyHtml: string;
   tags: string[];
   name: string;
   category: string;
@@ -20,8 +20,9 @@ export type TagListRequest = {}
 export type TagListResponse = {
   tags: Array<{
     name: string;
-    posts_count: number;
+    postsCount: number;
   }>;
+  totalCount: number;
 }
 
 export type SubmitTextToEsaRequest = {
@@ -32,10 +33,10 @@ export type SubmitTextToEsaRequest = {
 }
 
 export type SubmitTextToEsaResponse = {
-  updated_at: string;
+  updatedAt: string;
   url: string;
-  body_md: string;
-  body_html: string;
+  bodyMd: string;
+  bodyHtml: string;
   tags: string[];
   name: string;
   category: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,11 +1,7 @@
 import type { HttpsCallableResult } from 'firebase/functions';
 
-// リクエスト/レスポンスの型定義
-export type DailyReportRequest = {
-  category: string;
-}
-
-export type DailyReportResponse = {
+// 共通の型定義
+export type EsaPostResponse = {
   updatedAt: string;
   url: string;
   bodyMd: string;
@@ -13,7 +9,15 @@ export type DailyReportResponse = {
   tags: string[];
   name: string;
   category: string;
+  number: number;
 }
+
+// リクエスト/レスポンスの型定義
+export type DailyReportRequest = {
+  category: string;
+}
+
+export type DailyReportResponse = EsaPostResponse;
 
 export type TagListRequest = {}
 
@@ -32,24 +36,19 @@ export type SubmitTextToEsaRequest = {
   text: string;
 }
 
-export type SubmitTextToEsaResponse = {
-  updatedAt: string;
-  url: string;
-  bodyMd: string;
-  bodyHtml: string;
-  tags: string[];
-  name: string;
-  category: string;
-}
+export type SubmitTextToEsaResponse = EsaPostResponse;
 
 export type RecentDailyReportsRequest = {}
 
 export type RecentDailyReportsResponse = {
   reports: Array<{
     date: string;
-    url: string;
-    posts_count: number;
+    title: string;
+    category: string;
+    updatedAt: string;
+    number: number;
   }>;
+  totalCount: number;
 }
 
 // APIクライアントのインターフェース

--- a/src/components/EsaSubmitForm/index.tsx
+++ b/src/components/EsaSubmitForm/index.tsx
@@ -91,8 +91,8 @@ export const EsaSubmitForm: React.FC<EsaSubmitFormProps> = (props: EsaSubmitForm
       props.onSubmit(
         data.data.category,
         data.data.name,
-        data.data.body_md,
-        data.data.body_html,
+        data.data.bodyMd,
+        data.data.bodyHtml,
         data.data.tags,
       );
     } catch (err: any) {

--- a/src/components/TimesEsa/index.tsx
+++ b/src/components/TimesEsa/index.tsx
@@ -45,11 +45,11 @@ const TimesEsa: React.FC<TimesEsaProps> = (props: TimesEsaProps) => {
 
     try {
       const res = await getDailyReport(makeDefaultEsaCategory(new Date()));
-      setUpdatedAt(res.data.updated_at);
+      setUpdatedAt(res.data.updatedAt);
       setEsaUrl(res.data.url);
 
-      setEsaText(res.data.body_md);
-      setEsaHtml(res.data.body_html);
+      setEsaText(res.data.bodyMd);
+      setEsaHtml(res.data.bodyHtml);
       setEsaTags(res.data.tags);
       setEsaTitle(res.data.name);
       setEsaCategory(res.data.category);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export type GoogleUser = {
 // タグの型定義
 export type Tag = {
   name: string;
-  posts_count: number;
+  postsCount: number;
 }
 
 // 日報表示タイプのenum

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export type GoogleUser = {
   photoURL: string;
 }
 
-// タグの型定義
+// タグの型定義（バックエンドのEsaTagCamelCaseと同じ構造）
 export type Tag = {
   name: string;
   postsCount: number;


### PR DESCRIPTION
## 概要
esa APIからのレスポンスをバックエンドでキャメルケースに変換する機能を実装しました。これにより、フロントエンドでの変換処理が不要になり、よりクリーンなコード構造を実現します。

## 変更内容
- `caseConverter.ts`を新規作成し、esa APIレスポンス専用の変換関数を実装
  - `convertEsaPostToCamelCase`: 投稿データの変換
  - `convertEsaTagsToCamelCase`: タグリストの変換
- 各エンドポイント（`submitTextToEsa`, `dailyReport`, `tagList`）で変換関数を適用
- 型定義を`caseConverter.ts`に集約し、重複を排除
- テストファイルを追加し、変換ロジックの正確性を保証

## 実装方針
- 汎用的な再帰変換ではなく、esa APIの構造に特化した明示的な変換関数を実装
- タグ名など、値として使用される文字列は変換せず、フィールド名のみを変換
- 型安全性を維持しながら、保守性の高いコードを実現

## テスト
- `caseConverter.test.ts`で変換ロジックのユニットテストを実装
- 既存のテストも全て通過することを確認
- CIでのlintエラーも解決済み

## 今後の展望
この変更により、フロントエンド側でもキャメルケースの型定義を使用できるようになります。次のステップとして、フロントエンドの型定義の整理を予定しています。