### PR TITLE
feat(functions): add fetch-based EsaHttpClient as scaffolding for axios removal (YAS-332)

### DIFF
--- a/functions/src/__tests__/esaHttpClient.test.ts
+++ b/functions/src/__tests__/esaHttpClient.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createEsaClient, EsaHttpError } from '../esaHttpClient';
+
+const mockFetch = vi.fn();
+
+/**
+ * fetch に渡された [url, init] を型付きで取り出す。
+ * vitest の `MockInstance.mock.calls` は `any[][]` として型付けされているため、
+ * eslint の `no-unsafe-*` ルールに引っかからないようテスト側で境界のキャストを閉じる。
+ */
+function getFetchCallArgs(callIndex = 0): [URL, RequestInit] {
+  return mockFetch.mock.calls[callIndex] as unknown as [URL, RequestInit];
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('EsaHttpClient', () => {
+  describe('get', () => {
+    it('params を URL クエリとしてエンコードする', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, posts: [] }),
+      });
+
+      const client = createEsaClient('test-token');
+      const result = await client.get<{ total_count: number; posts: unknown[] }>(
+        '/v1/teams/foo/posts',
+        { params: { q: 'on:日報/2026/04/20', per_page: 20 } },
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [calledUrl, calledInit] = getFetchCallArgs();
+      expect(calledUrl).toBeInstanceOf(URL);
+      expect(calledUrl.href).toBe(
+        'https://api.esa.io/v1/teams/foo/posts?q=on%3A%E6%97%A5%E5%A0%B1%2F2026%2F04%2F20&per_page=20',
+      );
+      expect(calledInit).toMatchObject({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }) as unknown,
+      });
+      expect(calledInit.body).toBeUndefined();
+      expect(result).toEqual({ total_count: 0, posts: [] });
+    });
+
+    it('params 無しでも動く', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ tags: [], total_count: 0 }),
+      });
+
+      const client = createEsaClient('test-token');
+      const result = await client.get<{ tags: unknown[]; total_count: number }>(
+        '/v1/teams/foo/tags',
+      );
+
+      const [calledUrl, calledInit] = getFetchCallArgs();
+      expect(calledUrl.href).toBe('https://api.esa.io/v1/teams/foo/tags');
+      expect(calledInit).toMatchObject({ method: 'GET' });
+      expect(result).toEqual({ tags: [], total_count: 0 });
+    });
+
+    it('成功レスポンスが .data でラップされずそのまま返る', async () => {
+      const payload = {
+        total_count: 1,
+        posts: [{ number: 42, name: 'test', body_md: '', body_html: '', tags: [] }],
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(payload),
+      });
+
+      const client = createEsaClient('test-token');
+      const result = await client.get<typeof payload>('/v1/teams/foo/posts');
+
+      expect(result).toEqual(payload);
+      expect(result).not.toHaveProperty('data');
+    });
+  });
+
+  describe('post', () => {
+    it('body が JSON 文字列化されて送られる', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 1 }),
+      });
+
+      const client = createEsaClient('test-token');
+      await client.post<{ number: number }>('/v1/teams/foo/posts', {
+        post: { name: 'x' },
+      });
+
+      const [calledUrl, calledInit] = getFetchCallArgs();
+      expect(calledUrl.href).toBe('https://api.esa.io/v1/teams/foo/posts');
+      expect(calledInit).toMatchObject({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }) as unknown,
+      });
+      expect(calledInit.body).toBe('{"post":{"name":"x"}}');
+    });
+  });
+
+  describe('patch', () => {
+    it('method が PATCH で body が JSON 化される', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 42 }),
+      });
+
+      const client = createEsaClient('test-token');
+      await client.patch<{ number: number }>('/v1/teams/foo/posts/42', {
+        post: { body_md: 'updated' },
+      });
+
+      const [calledUrl, calledInit] = getFetchCallArgs();
+      expect(calledUrl.href).toBe('https://api.esa.io/v1/teams/foo/posts/42');
+      expect(calledInit).toMatchObject({ method: 'PATCH' });
+      expect(calledInit.body).toBe('{"post":{"body_md":"updated"}}');
+    });
+  });
+
+  describe('error handling', () => {
+    it('非 2xx で EsaHttpError が throw される (axios 互換形状)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'unauthorized', message: 'Invalid token' }),
+      });
+
+      const client = createEsaClient('bad-token');
+      let caught: unknown;
+      try {
+        await client.get('/v1/teams/foo/posts');
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(EsaHttpError);
+      const httpError = caught as EsaHttpError;
+      expect(httpError.name).toBe('EsaHttpError');
+      expect(httpError.message).toBe('unauthorized: Invalid token');
+      expect(httpError.response.status).toBe(401);
+      expect(httpError.response.data).toEqual({
+        error: 'unauthorized',
+        message: 'Invalid token',
+      });
+    });
+
+    it('レスポンス body が JSON 解析不能でも落ちず EsaHttpError で包む', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error('parse')),
+      });
+
+      const client = createEsaClient('test-token');
+      let caught: unknown;
+      try {
+        await client.get('/v1/teams/foo/posts');
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(EsaHttpError);
+      const httpError = caught as EsaHttpError;
+      expect(httpError.response.status).toBe(500);
+      expect(httpError.response.data).toEqual({});
+    });
+  });
+
+  describe('authentication header', () => {
+    it('異なる accessToken でクライアントを作れば別のトークンが送られる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      const clientA = createEsaClient('token-a');
+      const clientB = createEsaClient('token-b');
+
+      await clientA.get('/v1/teams/foo/posts');
+      await clientB.get('/v1/teams/foo/posts');
+
+      const [, initA] = getFetchCallArgs(0);
+      const [, initB] = getFetchCallArgs(1);
+      expect(initA.headers).toMatchObject({ Authorization: 'Bearer token-a' });
+      expect(initB.headers).toMatchObject({ Authorization: 'Bearer token-b' });
+    });
+  });
+});

--- a/functions/src/esaHttpClient.ts
+++ b/functions/src/esaHttpClient.ts
@@ -1,0 +1,77 @@
+/**
+ * esa.io API を叩くための薄い HTTP クライアント。
+ * axios の代替として Node.js 標準 fetch をラップする。
+ *
+ * 利用側が axios 時代と同じ書き味で使えるよう、.get / .post / .patch の
+ * 3 メソッドだけを提供する（axios の超サブセット）。
+ */
+
+import { type EsaErrorResponse } from './types';
+
+export interface EsaHttpClient {
+  get<T>(path: string, options?: { params?: Record<string, string | number> }): Promise<T>;
+  post<T>(path: string, body: unknown): Promise<T>;
+  patch<T>(path: string, body: unknown): Promise<T>;
+}
+
+/**
+ * axios の AxiosError.response.data と同じ形状を持つエラー。
+ * 既存の catch 節 (`err.response?.data.error` / `err.response?.data.message`) が
+ * そのまま動くように互換形状で投げる。
+ */
+export class EsaHttpError extends Error {
+  readonly response: { data: EsaErrorResponse; status: number };
+  constructor(status: number, data: EsaErrorResponse) {
+    super(`${data.error}: ${data.message}`);
+    this.name = 'EsaHttpError';
+    this.response = { data, status };
+  }
+}
+
+const BASE_URL = 'https://api.esa.io';
+
+export function createEsaClient(accessToken: string): EsaHttpClient {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  // esa.io API へ共通処理で fetch を呼ぶ内部ヘルパー。
+  // get / post / patch の共通実装をここに寄せる。
+  async function esaFetch<T>(
+    method: 'GET' | 'POST' | 'PATCH',
+    path: string,
+    options?: { params?: Record<string, string | number>; body?: unknown }
+  ): Promise<T> {
+    const url = new URL(path, BASE_URL);
+    if (options?.params) {
+      for (const [k, v] of Object.entries(options.params)) {
+        url.searchParams.set(k, String(v));
+      }
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: options?.body !== undefined ? JSON.stringify(options.body) : undefined,
+    });
+
+    if (!res.ok) {
+      // esa.io はエラー時に { error, message } の JSON を返す想定。
+      // body が JSON で無い場合も落ちないよう catch で空オブジェクトを返す。
+      const data = (await res.json().catch(() => ({}))) as EsaErrorResponse;
+      throw new EsaHttpError(res.status, data);
+    }
+
+    return (await res.json()) as T;
+  }
+
+  return {
+    get: <T>(path: string, options?: { params?: Record<string, string | number> }) =>
+      esaFetch<T>('GET', path, options),
+    post: <T>(path: string, body: unknown) =>
+      esaFetch<T>('POST', path, { body }),
+    patch: <T>(path: string, body: unknown) =>
+      esaFetch<T>('PATCH', path, { body }),
+  };
+}


### PR DESCRIPTION
## Summary

親 project [axiosの脱却](https://linear.app/yasuhisa/project/axios) の #2 ([YAS-332](https://linear.app/yasuhisa/issue/YAS-332))。axios を置き換える土台となる **fetch ベースの薄い HTTP クライアント** (`EsaHttpClient`) を新規追加する足場 PR。

**本 PR では既存 TypeScript コード (`index.ts` / `search.ts` / `recentDailyReports.ts` およびそのテスト) は 1 文字も触らない。** 新規ファイル 2 本 (実装 1 本 + テスト 1 本) を追加するだけ。ランタイム挙動の変更は無し。

### 追加ファイル

| ファイル | 内容 |
|---|---|
| `functions/src/esaHttpClient.ts` | fetch ラッパー本体。`createEsaClient(accessToken)` と `class EsaHttpError` を export |
| `functions/src/__tests__/esaHttpClient.test.ts` | `vi.stubGlobal('fetch', ...)` でモックしたユニットテスト 8 ケース |

### 設計ポイント

- **axios 互換エラー形状**: `EsaHttpError.response.data.error / message` と `.response.status` を持たせ、既存 catch 節 (`err.response?.data.error`) が後続 PR で無改修で動くようにしてある。
- **戻り値は `T` をそのまま返す** (axios の `.data` ラップをしない)。YAS-333 / YAS-334 で `response.data` アクセスを直戻り値に置換する方針と整合。
- **内部ヘルパー名は `esaFetch`** (`request` を避けた。npm の `request` パッケージや Python `requests` との紛らわしさ回避のため)。`createEsaClient` の closure 内に閉じているので外部影響なし。
- **body 非 JSON 時の挙動**: `res.json().catch(() => ({}))` で落ちないようにしている。この場合 `EsaHttpError.message` は `"undefined: undefined"` になるが axios 時代も `err.response?.data.error` が undefined になっていたため挙動変更なし。
- `AbortSignal` / timeout / retry は既存 axios 設定にも無いため現状再現として未実装。
- 外部ライブラリ追加なし (Node.js 24 の global fetch を利用)。

## Review & Testing Checklist for Human

- [ ] 後続 issue (YAS-333 / YAS-334) で本クライアントが実利用される想定。`AxiosInstance` → `EsaHttpClient` 置換の差分が「型置換」と「`response.data` → 直アクセス」の単純置換で済むかを、本 PR の I/F で目視確認 (特に search.ts / index.ts の既存 axios 呼び出しパターンとの対応)
- [ ] `EsaHttpError` の形状 (`err.response.data.error` / `err.response.data.message` / `err.response.status`) が既存 catch 節 (`index.ts` の `catch ((err: AxiosError<EsaErrorResponse>)` 周り) にそのまま刺さるかを一読
- [ ] esa.io API の実エラーレスポンスが `{ error, message }` 形状である前提 (既存コードの前提を踏襲) で OK か
- [ ] テストでは `vi.stubGlobal('fetch', mockFetch)` + `afterEach(vi.unstubAllGlobals)` を使っている。他のテストに副作用を与えないことをローカルで `npm test` で確認済

## 動作確認

```
$ cd functions
$ npm run build  # tsc 通過
$ npm test       # 101 passed (新規 8 + 既存 93)
$ npm run lint   # エラー 0
```

### Notes

- スコープ外 (本 PR ではやらない):
  - `index.ts` / `search.ts` / `recentDailyReports.ts` の axios 呼び出し置換 → YAS-333 / YAS-334
  - `functions/package.json` からの axios 物理削除 → YAS-335
  - フロントエンド (ルート `src/`) の変更
- branch 名に Linear 側で提案された ID (`yas-332`) は含めていないが、コミットメッセージ末尾に `Refs: YAS-332` を付けている

Link to Devin session: https://app.devin.ai/sessions/f8fc805332dc43d8a1dd988d0ee8eaf2
Requested by: @syou6162