### PR TITLE
[YAS-333] search.ts / recentDailyReports.ts を EsaHttpClient に移行する

### DIFF
--- a/functions/src/__tests__/index.test.ts
+++ b/functions/src/__tests__/index.test.ts
@@ -10,6 +10,7 @@ import { transformTitle, checkAuthTokenEmail, getDailyReport, createOrUpdatePost
 import { type EsaPostSnakeCase, type EsaTagsSnakeCase, type EsaSearchResult } from '../caseConverter';
 import { type RecentDailyReportsRequest } from '../types';
 import { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { EsaHttpClient } from '../esaHttpClient';
 
 
 describe('Firebase Functions Tests', () => {
@@ -220,10 +221,18 @@ describe('Firebase Functions Tests', () => {
   });
 
   describe('getDailyReport', () => {
-    // Axiosモックのタイプ定義
+    // Axiosモックのタイプ定義（詳細取得用）
     const mockAxios = {
       get: vi.fn(),
     };
+
+    // EsaHttpClient モック（searchDailyReport 用）
+    const mockEsaClientGet = vi.fn();
+    const mockEsaClient = {
+      get: mockEsaClientGet,
+      post: vi.fn(),
+      patch: vi.fn(),
+    } as unknown as EsaHttpClient;
 
     const mockEsaConfig = {
       teamName: 'test-team',
@@ -249,16 +258,6 @@ describe('Firebase Functions Tests', () => {
         total_count: 1,
       };
 
-      const searchResponse: AxiosResponse<EsaSearchResult> = {
-        data: searchResult,
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: {
-          headers: {},
-        } as InternalAxiosRequestConfig,
-      };
-
       const detailResponse: AxiosResponse<EsaPostSnakeCase> = {
         data: mockPost,
         status: 200,
@@ -270,25 +269,27 @@ describe('Firebase Functions Tests', () => {
       };
 
       // モックの設定
-      mockAxios.get
-        .mockResolvedValueOnce(searchResponse) // 最初の呼び出し（検索）
-        .mockResolvedValueOnce(detailResponse); // 2回目の呼び出し（詳細取得）
+      // searchDailyReport は EsaHttpClient 経由なので esa クライアントの mock にセット
+      mockEsaClientGet.mockResolvedValueOnce(searchResult);
+      // 詳細取得は引き続き axios 経由
+      mockAxios.get.mockResolvedValueOnce(detailResponse);
 
       // 実行
-      const result = await getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaConfig, '日報/2024/06/20');
+      const result = await getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaClient, mockEsaConfig, '日報/2024/06/20');
 
       // 検証
-      expect(mockAxios.get).toHaveBeenCalledTimes(2);
+      expect(mockEsaClientGet).toHaveBeenCalledTimes(1);
+      expect(mockAxios.get).toHaveBeenCalledTimes(1);
 
-      // 検索API呼び出しの検証
-      expect(mockAxios.get).toHaveBeenNthCalledWith(1, '/v1/teams/test-team/posts', {
+      // 検索API呼び出しの検証（EsaHttpClient）
+      expect(mockEsaClientGet).toHaveBeenCalledWith('/v1/teams/test-team/posts', {
         params: {
           q: 'on:日報/2024/06/20',
         },
       });
 
-      // 詳細取得API呼び出しの検証
-      expect(mockAxios.get).toHaveBeenNthCalledWith(2, '/v1/teams/test-team/posts/123');
+      // 詳細取得API呼び出しの検証（axios）
+      expect(mockAxios.get).toHaveBeenCalledWith('/v1/teams/test-team/posts/123');
 
       // 結果の検証
       expect(result).toEqual(mockPost);
@@ -301,24 +302,15 @@ describe('Firebase Functions Tests', () => {
         total_count: 0,
       };
 
-      const searchResponse: AxiosResponse<EsaSearchResult> = {
-        data: searchResult,
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: {
-          headers: {},
-        } as InternalAxiosRequestConfig,
-      };
-
-      mockAxios.get.mockResolvedValueOnce(searchResponse);
+      mockEsaClientGet.mockResolvedValueOnce(searchResult);
 
       // 実行と検証
-      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaConfig, '日報/2024/06/20'))
+      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaClient, mockEsaConfig, '日報/2024/06/20'))
         .rejects
         .toThrow(new functions.https.HttpsError('not-found', '指定された日の日報はまだありません'));
 
-      expect(mockAxios.get).toHaveBeenCalledTimes(1);
+      expect(mockEsaClientGet).toHaveBeenCalledTimes(1);
+      expect(mockAxios.get).not.toHaveBeenCalled();
     });
 
     it('should throw already-exists error when multiple daily reports exist', async () => {
@@ -345,44 +337,37 @@ describe('Firebase Functions Tests', () => {
         total_count: 2,
       };
 
-      const searchResponse: AxiosResponse<EsaSearchResult> = {
-        data: searchResult,
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: {
-          headers: {},
-        } as InternalAxiosRequestConfig,
-      };
-
-      mockAxios.get.mockResolvedValueOnce(searchResponse);
+      mockEsaClientGet.mockResolvedValueOnce(searchResult);
 
       // 実行と検証
-      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaConfig, '日報/2024/06/20'))
+      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaClient, mockEsaConfig, '日報/2024/06/20'))
         .rejects
         .toThrow(new functions.https.HttpsError('already-exists', '複数の日報が存在します'));
 
-      expect(mockAxios.get).toHaveBeenCalledTimes(1);
+      expect(mockEsaClientGet).toHaveBeenCalledTimes(1);
+      expect(mockAxios.get).not.toHaveBeenCalled();
     });
 
     it('should throw error for invalid category format', async () => {
       // 曜日付きカテゴリはサポートしない
-      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaConfig, '日報/2024/06/20 (金)'))
+      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaClient, mockEsaConfig, '日報/2024/06/20 (金)'))
         .rejects
         .toThrow(new functions.https.HttpsError('invalid-argument', 'カテゴリの形式が正しくありません'));
 
       // APIが呼ばれていないことを確認
       expect(mockAxios.get).not.toHaveBeenCalled();
+      expect(mockEsaClientGet).not.toHaveBeenCalled();
     });
 
     it('should throw error for non-date category format', async () => {
       // 日付形式ではないカテゴリでテスト
-      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaConfig, 'テストカテゴリ'))
+      await expect(getDailyReport(mockAxios as unknown as AxiosInstance, mockEsaClient, mockEsaConfig, 'テストカテゴリ'))
         .rejects
         .toThrow(new functions.https.HttpsError('invalid-argument', 'カテゴリの形式が正しくありません'));
 
       // APIが呼ばれていないことを確認
       expect(mockAxios.get).not.toHaveBeenCalled();
+      expect(mockEsaClientGet).not.toHaveBeenCalled();
     });
   });
 
@@ -838,7 +823,7 @@ describe('Firebase Functions Tests', () => {
 
       const result = await recentDailyReports.run(mockContext);
 
-      expect(mockGetRecentDailyReports).toHaveBeenCalledWith(10); // デフォルト値
+      expect(mockGetRecentDailyReports).toHaveBeenCalledWith(expect.anything(), 10); // デフォルト値
       expect(result.reports).toHaveLength(1);
       expect(result.reports[0].title).toBe('テスト日報');
     });
@@ -863,7 +848,7 @@ describe('Firebase Functions Tests', () => {
 
       await recentDailyReports.run(contextWithDays);
 
-      expect(mockGetRecentDailyReports).toHaveBeenCalledWith(20);
+      expect(mockGetRecentDailyReports).toHaveBeenCalledWith(expect.anything(), 20);
     });
 
     it('daysが0以下の場合、invalid-argumentエラーをスローする', async () => {
@@ -997,10 +982,14 @@ describe('Firebase Functions Tests', () => {
     });
 
     it('ネットワークエラーなどの一般的なエラーが適切に伝播される', async () => {
-      mockAxios.get.mockRejectedValueOnce(new Error('Network timeout'));
+      const mockEsaClient = {
+        get: vi.fn().mockRejectedValueOnce(new Error('Network timeout')),
+        post: vi.fn(),
+        patch: vi.fn(),
+      } as unknown as EsaHttpClient;
 
       await expect(
-        getDailyReport(mockAxios, esaConfig, '日報/2024/06/20'),
+        getDailyReport(mockAxios, mockEsaClient, esaConfig, '日報/2024/06/20'),
       ).rejects.toThrow('エラーが発生しました');
     });
   });

--- a/functions/src/__tests__/recentDailyReports.test.ts
+++ b/functions/src/__tests__/recentDailyReports.test.ts
@@ -6,9 +6,17 @@ import {
 } from '../recentDailyReports';
 import * as search from '../search';
 import type { EsaPostSnakeCase } from '../caseConverter';
+import type { EsaHttpClient } from '../esaHttpClient';
 
 // searchPostsをモック
 vi.mock('../search');
+
+// テスト用のダミークライアント
+const mockEsaClient = {
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+} as unknown as EsaHttpClient;
 
 describe('recentDailyReports', () => {
   beforeEach(() => {
@@ -90,15 +98,15 @@ describe('recentDailyReports', () => {
       const searchPostsMock = vi.mocked(search.searchPosts);
       searchPostsMock.mockResolvedValue(mockSearchResult);
 
-      const result = await getRecentDailyReports(5);
+      const result = await getRecentDailyReports(mockEsaClient, 5);
 
       // searchPostsが正しいパラメータで呼ばれたか確認
-      expect(searchPostsMock).toHaveBeenCalledWith({
+      expect(searchPostsMock).toHaveBeenCalledWith(mockEsaClient, {
         options: [{ query: expect.stringContaining('on:日報/') as string }],
         perPage: 5,
         sort: 'updated',
         order: 'desc'
-      }, undefined);
+      });
 
       // 結果の確認
       expect(result.reports).toHaveLength(2);
@@ -149,7 +157,7 @@ describe('recentDailyReports', () => {
       const searchPostsMock = vi.mocked(search.searchPosts);
       searchPostsMock.mockResolvedValue(mockSearchResult);
 
-      const result = await getRecentDailyReports(5);
+      const result = await getRecentDailyReports(mockEsaClient, 5);
 
       // 日報のみが含まれることを確認
       expect(result.reports).toHaveLength(1);
@@ -165,7 +173,7 @@ describe('recentDailyReports', () => {
       const searchPostsMock = vi.mocked(search.searchPosts);
       searchPostsMock.mockResolvedValue(mockSearchResult);
 
-      const result = await getRecentDailyReports(10);
+      const result = await getRecentDailyReports(mockEsaClient, 10);
 
       expect(result.reports).toHaveLength(0);
       expect(result.total_count).toBe(0);

--- a/functions/src/__tests__/search.test.ts
+++ b/functions/src/__tests__/search.test.ts
@@ -1,22 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { searchPosts, searchDailyReport } from '../search';
 import { type SearchOption } from '../searchOptions';
-import type { AxiosInstance } from 'axios';
+import type { EsaHttpClient } from '../esaHttpClient';
 import type { EsaSearchResult } from '../caseConverter';
 
-// モック用のAxiosクライアント
+// モック用の EsaHttpClient
 const mockGet = vi.fn();
-const mockAxiosClient = {
-  get: mockGet
-} as unknown as AxiosInstance;
+const mockEsaClient = {
+  get: mockGet,
+  post: vi.fn(),
+  patch: vi.fn(),
+} as unknown as EsaHttpClient;
 
 // モック用のESA設定
 vi.mock('../index', () => ({
   getEsaConfig: () => ({
     accessToken: 'test-token',
     teamName: 'test-team'
-  }),
-  createAxiosClient: () => mockAxiosClient
+  })
 }));
 
 describe('search', () => {
@@ -39,13 +40,13 @@ describe('search', () => {
         total_count: 1
       };
 
-      mockGet.mockResolvedValueOnce({ data: mockResponse });
+      mockGet.mockResolvedValueOnce(mockResponse);
 
       const options: SearchOption[] = [
         { query: 'on:日報/2024/06/20' }
       ];
 
-      const result = await searchPosts({ options }, mockAxiosClient);
+      const result = await searchPosts(mockEsaClient, { options });
 
       expect(mockGet).toHaveBeenCalledWith(
         '/v1/teams/test-team/posts',
@@ -68,7 +69,7 @@ describe('search', () => {
         total_count: 0
       };
 
-      mockGet.mockResolvedValueOnce({ data: mockResponse });
+      mockGet.mockResolvedValueOnce(mockResponse);
 
       const options: SearchOption[] = [
         { query: 'on:日報/2024/06/21' },
@@ -76,13 +77,13 @@ describe('search', () => {
         { query: 'wip:false' }
       ];
 
-      const result = await searchPosts({
+      const result = await searchPosts(mockEsaClient, {
         options,
         page: 2,
         perPage: 50,
         sort: 'created',
         order: 'asc'
-      }, mockAxiosClient);
+      });
 
       expect(mockGet).toHaveBeenCalledWith(
         '/v1/teams/test-team/posts',
@@ -105,9 +106,9 @@ describe('search', () => {
         total_count: 0
       };
 
-      mockGet.mockResolvedValueOnce({ data: mockResponse });
+      mockGet.mockResolvedValueOnce(mockResponse);
 
-      const result = await searchPosts({ options: [] }, mockAxiosClient);
+      const result = await searchPosts(mockEsaClient, { options: [] });
 
       expect(mockGet).toHaveBeenCalledWith(
         '/v1/teams/test-team/posts',
@@ -129,7 +130,7 @@ describe('search', () => {
       mockGet.mockRejectedValueOnce(error);
 
       await expect(
-        searchPosts({ options: [] }, mockAxiosClient)
+        searchPosts(mockEsaClient, { options: [] })
       ).rejects.toThrow('API Error');
     });
   });
@@ -149,9 +150,9 @@ describe('search', () => {
         total_count: 1
       };
 
-      mockGet.mockResolvedValueOnce({ data: mockResponse });
+      mockGet.mockResolvedValueOnce(mockResponse);
 
-      const result = await searchDailyReport('2024-06-20', mockAxiosClient);
+      const result = await searchDailyReport(mockEsaClient, '2024-06-20');
 
       expect(mockGet).toHaveBeenCalledWith(
         '/v1/teams/test-team/posts',
@@ -170,9 +171,9 @@ describe('search', () => {
         total_count: 0
       };
 
-      mockGet.mockResolvedValueOnce({ data: mockResponse });
+      mockGet.mockResolvedValueOnce(mockResponse);
 
-      await searchDailyReport('2024-01-05', mockAxiosClient);
+      await searchDailyReport(mockEsaClient, '2024-01-05');
 
       expect(mockGet).toHaveBeenCalledWith(
         '/v1/teams/test-team/posts',

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { setGlobalOptions } from 'firebase-functions/v2'
 import { CallableRequest, onCall } from 'firebase-functions/v2/https';
 import { searchDailyReport } from './search';
+import { createEsaClient, type EsaHttpClient } from './esaHttpClient';
 import { formatCategoryToDate } from './dateUtils';
 import { type DailyReportCategory, type DateString } from '../../types/domain';
 import {
@@ -139,6 +140,7 @@ export async function createOrUpdatePost(
 
 export async function getDailyReport(
   axiosClient: AxiosInstance,
+  esaClient: EsaHttpClient,
   esaConfig: EsaConfig,
   category: DailyReportCategory,
 ): Promise<EsaPostSnakeCase> {
@@ -152,7 +154,7 @@ export async function getDailyReport(
   }
 
   try {
-    const response = await searchDailyReport(targetDate, axiosClient);
+    const response = await searchDailyReport(esaClient, targetDate);
 
     if (response.total_count === 0) {
       throw new functions.https.HttpsError('not-found', '指定された日の日報はまだありません');
@@ -222,7 +224,8 @@ export const dailyReport = onCall(
 
     const esaConfig = getEsaConfig();
     const axios = createAxiosClient(esaConfig.accessToken);
-    const result = await getDailyReport(axios, esaConfig, req.data.category);
+    const esaClient = createEsaClient(esaConfig.accessToken);
+    const result = await getDailyReport(axios, esaClient, esaConfig, req.data.category);
     return convertEsaPostToCamelCase(result);
   }
 );
@@ -256,8 +259,11 @@ export const recentDailyReports = onCall(
       throw new functions.https.HttpsError('invalid-argument', 'daysパラメータは1から31の範囲で指定してください');
     }
 
+    const esaConfig = getEsaConfig();
+    const esaClient = createEsaClient(esaConfig.accessToken);
+
     try {
-      const result = await getRecentDailyReports(days);
+      const result = await getRecentDailyReports(esaClient, days);
       return convertRecentDailyReportsResponseToCamelCase(result);
     } catch (error) {
       console.error('recentDailyReports error:', error);

--- a/functions/src/recentDailyReports.ts
+++ b/functions/src/recentDailyReports.ts
@@ -2,7 +2,7 @@
  * 過去の日報リストを取得するための機能
  */
 
-import { AxiosInstance } from 'axios';
+import { type EsaHttpClient } from './esaHttpClient';
 import { searchPosts } from './search';
 import { getDateRangeCategories, formatCategoryToDate, isDailyReportCategory } from './dateUtils';
 import { type DailyReportCategory } from '../../types/domain';
@@ -41,13 +41,13 @@ export function extractDailyReportSummary(post: EsaPostSnakeCase & { category: D
 
 /**
  * 過去の日報リストを取得する
+ * @param client - esa.io 用 HTTP クライアント
  * @param days - 取得する日数（デフォルト: 10）
- * @param axiosClient - Axiosクライアント（テスト用にオプション）
  * @returns 日報リストと総数
  */
 export async function getRecentDailyReports(
-  days: number = 10,
-  axiosClient?: AxiosInstance
+  client: EsaHttpClient,
+  days: number = 10
 ): Promise<{ reports: DailyReportSummarySnakeCase[]; total_count: number }> {
   // 過去N日分のカテゴリを生成
   const categories = getDateRangeCategories(days);
@@ -56,12 +56,12 @@ export async function getRecentDailyReports(
   const query = createMultipleCategoryQuery(categories);
 
   // 検索実行
-  const result = await searchPosts({
+  const result = await searchPosts(client, {
     options: [{ query }],
     perPage: days, // 最大でも指定日数分しか存在しないはず
     sort: 'updated',
     order: 'desc'
-  }, axiosClient);
+  });
 
   // 結果を日報サマリー形式に変換
   const reports = result.posts

--- a/functions/src/search.ts
+++ b/functions/src/search.ts
@@ -2,9 +2,9 @@
  * ESA APIを使用した汎用的な投稿検索機能
  */
 
-import { AxiosInstance } from 'axios';
+import { type EsaHttpClient } from './esaHttpClient';
 import { SearchOption, combineOptions } from './searchOptions';
-import { createAxiosClient, getEsaConfig } from './index';
+import { getEsaConfig } from './index';
 import { type EsaSearchResult } from './caseConverter';
 
 /**
@@ -20,15 +20,14 @@ export interface SearchParams {
 
 /**
  * 汎用的な投稿検索関数
+ * @param client - esa.io 用 HTTP クライアント
  * @param params - 検索パラメータ
- * @param axiosClient - Axiosクライアント（テスト用にオプション）
  * @returns 検索結果
  */
 export async function searchPosts(
-  params: SearchParams,
-  axiosClient?: AxiosInstance
+  client: EsaHttpClient,
+  params: SearchParams
 ): Promise<EsaSearchResult> {
-  const client = axiosClient || createAxiosClient();
   const config = getEsaConfig();
 
   // 検索クエリを構築
@@ -43,25 +42,22 @@ export async function searchPosts(
     order: params.order || 'desc'
   };
 
-  const response = await client.get<EsaSearchResult>(
+  return await client.get<EsaSearchResult>(
     `/v1/teams/${config.teamName}/posts`,
     { params: apiParams }
   );
-
-  return response.data;
 }
 
 /**
  * 日報を検索する関数（特定の日付のカテゴリで検索）
+ * @param client - esa.io 用 HTTP クライアント
  * @param date - 日付（YYYY-MM-DD形式）
- * @param axiosClient - Axiosクライアント（テスト用にオプション）
  * @returns 検索結果
  */
 export async function searchDailyReport(
-  date: string,
-  axiosClient?: AxiosInstance
+  client: EsaHttpClient,
+  date: string
 ): Promise<EsaSearchResult> {
-  const client = axiosClient || createAxiosClient();
   const config = getEsaConfig();
 
   // 日付からカテゴリを構築（日報は日付まで含むカテゴリ構造）
@@ -69,7 +65,7 @@ export async function searchDailyReport(
   const category = `日報/${year}/${month}/${day}`;
 
   // 完全一致検索で特定の日付の日報を取得
-  const response = await client.get<EsaSearchResult>(
+  return await client.get<EsaSearchResult>(
     `/v1/teams/${config.teamName}/posts`,
     {
       params: {
@@ -77,6 +73,4 @@ export async function searchDailyReport(
       }
     }
   );
-
-  return response.data;
 }


### PR DESCRIPTION
## Summary

親プロジェクト [`axiosの脱却`](https://linear.app/yasuhisa/issue/YAS-333) の第 3 弾。[YAS-332 / PR #849](https://github.com/syou6162/times_esa/pull/849) で導入した `EsaHttpClient` を、`search.ts` / `recentDailyReports.ts` の各関数に適用する。

### 変更内容

- `functions/src/search.ts`
  - `searchPosts` / `searchDailyReport` の第一引数を `EsaHttpClient`（required）に変更
  - 内部での `createAxiosClient()` フォールバックを削除
  - `response.data` の unwrap を撤廃（`EsaHttpClient` は `T` を直接返す）
  - `axios` import を撤去
- `functions/src/recentDailyReports.ts`
  - `getRecentDailyReports(client: EsaHttpClient, days = 10)` に変更
  - `axios` import を撤去
- `functions/src/index.ts`（最小グルーのみ）
  - `dailyReport` onCall handler に `createEsaClient(accessToken)` 生成を追加し、`getDailyReport` に `esaClient` を渡す
  - `getDailyReport(axiosClient, esaClient, esaConfig, category)` に `esaClient` 引数を追加（`searchDailyReport` 呼び出しのため）。詳細取得 (`/posts/{number}`) は引き続き axios 経由。過渡期的に両クライアントを保持
  - `recentDailyReports` onCall handler で `createEsaClient` を生成し `getRecentDailyReports(client, days)` に渡す
  - `createAxiosClient` / `createOrUpdatePost` / `getTagList` / `submitTextToEsa` / `tagList` onCall の axios 利用は一切触らない（YAS-334 範囲）
- テスト追従
  - `__tests__/search.test.ts`: mock を EsaHttpClient 形状に（`{ data: X }` wrap 撤廃、`vi.mock('../index')` から `createAxiosClient` 削除、引数順を `(client, params)` に）
  - `__tests__/recentDailyReports.test.ts`: `getRecentDailyReports(mockClient, N)` / `toHaveBeenCalledWith(mockClient, {...})`
  - `__tests__/index.test.ts`: `getDailyReport` テスト群で EsaHttpClient mock を追加しシグネチャ追従。`recentDailyReports Cloud Function` の `toHaveBeenCalledWith(N)` を `toHaveBeenCalledWith(expect.anything(), N)` に

### 確認コマンド結果（ローカル）

- `npm run build`: OK
- `npm test -- --run`: 101/101 passed
- `npm run lint`: OK

## Review & Testing Checklist for Human

- [ ] **Firebase emulator 疎通確認**: user 側で手動実施（合意済）。以下 Cloud Function の regression が出ないことを確認してほしい
  - [ ] `dailyReport` onCall（= `getDailyReport`、検索は EsaHttpClient 経由 / 詳細取得は axios 経由に変わっている）
  - [ ] `recentDailyReports` onCall（= `getRecentDailyReports`、EsaHttpClient 経由）
  - [ ] `submitTextToEsa` / `tagList` onCall（本 PR で変更していないが、index.ts を触ったため念のため確認）
- [ ] `getDailyReport` が axios と EsaHttpClient を両方受け取る過渡期シグネチャになっている点の是非（YAS-334 で axios 側も `getDailyReport` 内 `/posts/{number}` 取得を含めて EsaHttpClient 化する想定）
- [ ] `search.ts` / `recentDailyReports.ts` から `axios` import が消えていること

### Notes

- Open Question 回答に従い:
  - Q1: `getDailyReport` への最小グルー追加を本 issue で実施（(a) 案）
  - Q2: Firebase emulator 疎通確認は user 側で PR レビュー時に実施
- `searchDailyReport` のシグネチャ変更により `index.ts:getDailyReport` が必然的に型エラーとなるため、`EsaHttpClient` を受け取るよう glue を追加した。「最小グルー」の範囲は `searchDailyReport` 呼び出し箇所の追従に限定し、`/posts/{number}` の詳細取得は axios のまま据え置き（YAS-334 で置換予定）。
- クライアント系引数を関数シグネチャの先頭に揃える方針に従い、`getDailyReport(axiosClient, esaClient, esaConfig, category)` の順序とした。

Refs: [YAS-333](https://linear.app/yasuhisa/issue/YAS-333)

Link to Devin session: https://app.devin.ai/sessions/8378c7cdf8fe4f7e83dbe543e6af365e
Requested by: @syou6162
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/syou6162/times_esa/pull/850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
