### PR TITLE
docs: update axios reference to fetch + EsaHttpClient (YAS-338)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ src/
 - **Firebase Cloud Functions** - サーバーレス実行環境
 - **Node.js 22** - ランタイム
 - **TypeScript 5.8** - 型安全性の確保
-- **Axios** - HTTP クライアント
+- **fetch (Node.js 標準) + EsaHttpClient** - HTTP クライアント (`functions/src/esaHttpClient.ts`)
 
 ### Cloud Functions一覧
 | 関数名 | 機能 | 説明 |


### PR DESCRIPTION
## Summary

[YAS-338](https://linear.app/yasuhisa/issue/YAS-338/times-esa-docsarchitecturemd-の-axios-記述を-esahttpclient-ベースに更新する) 対応。

`axios 脱却` project ([YAS-335](https://linear.app/yasuhisa/issue/YAS-335/times-esa-axios-を-packagejson-から完全撤去する) 完了済) 後も `docs/architecture.md` L64 に `**Axios** - HTTP クライアント` という記述が残っており、実態 (`fetch` + `EsaHttpClient`) と乖離していたため修正。

### 変更内容

- `docs/architecture.md` L64 の `- **Axios** - HTTP クライアント` を以下に置き換え:
  - `- **fetch (Node.js 標準) + EsaHttpClient** - HTTP クライアント (\`functions/src/esaHttpClient.ts\`)`

### スコープ外 (issue で明示)

- `.kiro/steering/backend-rules.md` の axios 記述 (kiro は使わないため触らない / 別 PR [#853](https://github.com/syou6162/times_esa/pull/853) で `.kiro/` ごと削除済)
- `functions/` 配下のコード変更 ([YAS-335](https://linear.app/yasuhisa/issue/YAS-335) 完了時点で対応済)

### 確認

- `docs/architecture.md` 内の `axios` / `Axios` 出現回数: 0 件 (grep 確認済)

## Review & Testing Checklist for Human

- [ ] 記述が実装実態 (`functions/src/esaHttpClient.ts` が `fetch` をラップしている) と一致していることを確認
- [ ] 他に更新漏れのドキュメントが無いこと (`CLAUDE.md` は YAS-335 で対応済)

### Notes

ドキュメントのみの変更で、コード / 挙動への影響はありません。

Link to Devin session: https://app.devin.ai/sessions/4be01f9cfef8453cbbae627e32782a78
Requested by: @syou6162