### PR TITLE
Add Oura integration: client, helpers, types, and tests

### DIFF
--- a/src/times_esa_talk/integrations/oura/client.py
+++ b/src/times_esa_talk/integrations/oura/client.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import date as dt_date
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Final
+
+import aiohttp
+
+from times_esa_talk.integrations.oura.helpers import (
+    ACTIVITY_METRIC_LABELS,
+    CONTRIBUTOR_LABELS_ACTIVITY,
+    CONTRIBUTOR_LABELS_READINESS,
+    format_int_count,
+    format_jst_timestamp,
+    format_kcal,
+    format_meters_to_km,
+    format_seconds_to_hm,
+    score_to_activity_label,
+    score_to_readiness_label,
+)
+from times_esa_talk.integrations.oura.types import (
+    ActivityMetric,
+    Contributor,
+    DailyActivity,
+    DailyReadiness,
+)
+
+OURA_API_BASE_URL: Final[str] = "https://api.ouraring.com/v2/usercollection"
+
+if TYPE_CHECKING:
+    from times_esa_talk.integrations.oura.token_store import OuraTokenStore
+
+
+class OuraClient:
+    def __init__(self, token_store: OuraTokenStore) -> None:
+        self._token_store = token_store
+
+    async def fetch_daily_readiness(self, date: str) -> DailyReadiness | None:
+        item = await self._fetch_range("daily_readiness", date)
+        if not item:
+            return None
+
+        contributors = self._build_contributors(
+            item.get("contributors", {}), CONTRIBUTOR_LABELS_READINESS
+        )
+        score = item.get("score")
+        return DailyReadiness(
+            date=date,
+            timestamp=format_jst_timestamp(item.get("timestamp")),
+            score=score,
+            score_label=score_to_readiness_label(score),
+            temperature_deviation=item.get("temperature_deviation"),
+            temperature_trend_deviation=item.get("temperature_trend_deviation"),
+            contributors=contributors,
+        )
+
+    async def fetch_daily_activity(self, date: str) -> DailyActivity | None:
+        item = await self._fetch_range("daily_activity", date)
+        if not item:
+            return None
+
+        contributors = self._build_contributors(
+            item.get("contributors", {}), CONTRIBUTOR_LABELS_ACTIVITY
+        )
+        metrics = self._build_activity_metrics(item)
+        score = item.get("score")
+        return DailyActivity(
+            date=date,
+            timestamp=format_jst_timestamp(item.get("timestamp")),
+            score=score,
+            score_label=score_to_activity_label(score),
+            metrics=metrics,
+            contributors=contributors,
+        )
+
+    async def _fetch_range(self, endpoint: str, date: str) -> dict[str, Any]:
+        target_day = dt_date.fromisoformat(date)
+        params = {
+            "start_date": (target_day - timedelta(days=1)).isoformat(),
+            "end_date": (target_day + timedelta(days=1)).isoformat(),
+        }
+
+        access_token = await self._token_store.get_access_token()
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{OURA_API_BASE_URL}/{endpoint}",
+                params=params,
+                headers=headers,
+            ) as response:
+                response.raise_for_status()
+                payload: dict[str, Any] = await response.json()
+
+        for item in payload.get("data", []):
+            if item.get("day") == date:
+                return item
+        return {}
+
+    @staticmethod
+    def _build_contributors(
+        raw_contributors: dict[str, int | None],
+        labels: dict[str, str],
+    ) -> list[Contributor]:
+        contributors: list[Contributor] = []
+        for key, label in labels.items():
+            value = raw_contributors.get(key)
+            if value is None:
+                continue
+            contributors.append(Contributor(key=key, label_ja=label, value=value))
+        return contributors
+
+    @staticmethod
+    def _build_activity_metrics(item: dict[str, Any]) -> list[ActivityMetric]:
+        metrics: list[ActivityMetric] = []
+        for key, label in ACTIVITY_METRIC_LABELS.items():
+            value_raw = item.get(key)
+            if value_raw is None:
+                continue
+            metrics.append(
+                ActivityMetric(
+                    key=key,
+                    label_ja=label,
+                    value_raw=value_raw,
+                    value_display=OuraClient._format_activity_metric(key, value_raw),
+                )
+            )
+        return metrics
+
+    @staticmethod
+    def _format_activity_metric(key: str, value: float | int) -> str | None:
+        if key in {
+            "high_activity_time",
+            "medium_activity_time",
+            "low_activity_time",
+            "sedentary_time",
+            "resting_time",
+            "non_wear_time",
+        }:
+            return format_seconds_to_hm(int(value))
+
+        if key in {"equivalent_walking_distance", "target_meters", "meters_to_target"}:
+            return format_meters_to_km(value)
+
+        if key in {"active_calories", "total_calories", "target_calories"}:
+            return format_kcal(value)
+
+        if key == "steps":
+            return format_int_count(int(value), "歩")
+
+        if key == "inactivity_alerts":
+            return format_int_count(int(value), "回")
+
+        if key in {
+            "high_activity_met_minutes",
+            "medium_activity_met_minutes",
+            "low_activity_met_minutes",
+            "sedentary_met_minutes",
+        }:
+            return str(int(value))
+
+        if key == "average_met_minutes":
+            return str(value)
+
+        return str(value)

--- a/src/times_esa_talk/integrations/oura/helpers.py
+++ b/src/times_esa_talk/integrations/oura/helpers.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Final
+
+JST: Final = timezone(timedelta(hours=9))
+
+CONTRIBUTOR_LABELS_READINESS: Final[dict[str, str]] = {
+    "previous_night": "睡眠(previous_night)",
+    "sleep_balance": "睡眠バランス(sleep_balance)",
+    "previous_day_activity": "前日のアクティビティ(previous_day_activity)",
+    "activity_balance": "アクティビティバランス(activity_balance)",
+    "resting_heart_rate": "安静時心拍数(resting_heart_rate)",
+    "hrv_balance": "心拍変動バランス(hrv_balance)",
+    "body_temperature": "体表温(body_temperature)",
+    "recovery_index": "回復指数(recovery_index)",
+    "sleep_regularity": "睡眠の規則性(sleep_regularity)",
+}
+
+CONTRIBUTOR_LABELS_ACTIVITY: Final[dict[str, str]] = {
+    "meet_daily_targets": "目標達成度(meet_daily_targets)",
+    "move_every_hour": "毎時間移動(move_every_hour)",
+    "recovery_time": "回復時間(recovery_time)",
+    "stay_active": "アクティブ維持(stay_active)",
+    "training_frequency": "運動頻度(training_frequency)",
+    "training_volume": "運動量(training_volume)",
+}
+
+ACTIVITY_METRIC_LABELS: Final[dict[str, str]] = {
+    "steps": "歩数(steps)",
+    "active_calories": "アクティブカロリー(active_calories)",
+    "total_calories": "総カロリー(total_calories)",
+    "equivalent_walking_distance": "歩行相当距離(equivalent_walking_distance)",
+    "high_activity_time": "高強度時間(high_activity_time)",
+    "medium_activity_time": "中強度時間(medium_activity_time)",
+    "low_activity_time": "低強度時間(low_activity_time)",
+    "sedentary_time": "座位時間(sedentary_time)",
+    "resting_time": "休息時間(resting_time)",
+    "non_wear_time": "非装着時間(non_wear_time)",
+    "high_activity_met_minutes": "高強度MET分(high_activity_met_minutes)",
+    "medium_activity_met_minutes": "中強度MET分(medium_activity_met_minutes)",
+    "low_activity_met_minutes": "低強度MET分(low_activity_met_minutes)",
+    "sedentary_met_minutes": "座位MET分(sedentary_met_minutes)",
+    "average_met_minutes": "平均MET(average_met_minutes)",
+    "inactivity_alerts": "非活動アラート(inactivity_alerts)",
+    "target_calories": "目標カロリー(target_calories)",
+    "target_meters": "目標距離(target_meters)",
+    "meters_to_target": "目標残り(meters_to_target)",
+}
+
+
+def score_to_readiness_label(score: int | None) -> str | None:
+    if score is None:
+        return None
+    if score >= 85:
+        return "Optimal"
+    if score >= 70:
+        return "Good"
+    return "Pay Attention"
+
+
+def score_to_activity_label(score: int | None) -> str | None:
+    if score is None:
+        return None
+    if score >= 85:
+        return "Optimal"
+    if score >= 70:
+        return "Good"
+    return "Below Average"
+
+
+def format_seconds_to_hm(seconds: int | None) -> str | None:
+    if seconds is None:
+        return None
+    minutes_total = seconds // 60
+    hours, minutes = divmod(minutes_total, 60)
+    if hours == 0:
+        return f"{minutes}分"
+    return f"{hours}時間{minutes}分"
+
+
+def format_meters_to_km(meters: float | int | None) -> str | None:
+    if meters is None:
+        return None
+    return f"{float(meters) / 1000:.1f} km"
+
+
+def format_kcal(kcal: float | int | None) -> str | None:
+    if kcal is None:
+        return None
+    return f"{int(kcal)} kcal"
+
+
+def format_int_count(value: int | None, suffix: str) -> str | None:
+    if value is None:
+        return None
+    return f"{value}{suffix}"
+
+
+def format_jst_timestamp(iso_str: str | None) -> str | None:
+    if iso_str is None:
+        return None
+    iso_normalized = iso_str.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(iso_normalized)
+    return parsed.astimezone(JST).strftime("%Y-%m-%d %H:%M JST")

--- a/src/times_esa_talk/integrations/oura/types.py
+++ b/src/times_esa_talk/integrations/oura/types.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Contributor(BaseModel):
+    key: str
+    label_ja: str
+    value: int | None
+
+
+class ActivityMetric(BaseModel):
+    key: str
+    label_ja: str
+    value_raw: float | int | None
+    value_display: str | None
+
+
+class DailyReadiness(BaseModel):
+    date: str
+    timestamp: str | None
+    score: int | None
+    score_label: str | None
+    temperature_deviation: float | None
+    temperature_trend_deviation: float | None
+    contributors: list[Contributor]
+
+
+class DailyActivity(BaseModel):
+    date: str
+    timestamp: str | None
+    score: int | None
+    score_label: str | None
+    metrics: list[ActivityMetric]
+    contributors: list[Contributor]

--- a/tests/integrations/oura/test_client.py
+++ b/tests/integrations/oura/test_client.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+
+from times_esa_talk.integrations.oura.client import OURA_API_BASE_URL, OuraClient
+
+
+class DummyResponse:
+    def __init__(self, *, payload: dict[str, Any], status: int, request_info: Any = None) -> None:
+        self._payload = payload
+        self.status = status
+        self.request_info = request_info
+
+    async def __aenter__(self) -> DummyResponse:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(
+                request_info=self.request_info,
+                history=(),
+                status=self.status,
+                message=f"HTTP {self.status}",
+            )
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, handler: Callable[[str, dict[str, str], dict[str, str]], DummyResponse]) -> None:
+        self._handler = handler
+
+    async def __aenter__(self) -> DummySession:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    def get(self, url: str, *, params: dict[str, str], headers: dict[str, str]) -> DummyResponse:
+        return self._handler(url, params, headers)
+
+
+@pytest.fixture
+def token_store() -> AsyncMock:
+    mock = AsyncMock()
+    mock.get_access_token.return_value = "dummy-token"
+    return mock
+
+
+def patch_client_session(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[str, dict[str, str], dict[str, str]], DummyResponse],
+) -> None:
+    monkeypatch.setattr(
+        "times_esa_talk.integrations.oura.client.aiohttp.ClientSession",
+        lambda: DummySession(handler),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_daily_readiness_success(token_store: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "data": [
+            {
+                "day": "2026-04-20",
+                "score": 82,
+                "temperature_deviation": 0.1,
+                "temperature_trend_deviation": -0.2,
+                "timestamp": "2026-04-20T06:00:00+09:00",
+                "contributors": {"previous_night": 70, "sleep_balance": 60},
+            }
+        ]
+    }
+
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload=payload, status=200),
+    )
+
+    client = OuraClient(token_store=token_store)
+    result = await client.fetch_daily_readiness("2026-04-20")
+
+    assert result is not None
+    assert result.score_label == "Good"
+
+
+@pytest.mark.asyncio
+async def test_fetch_daily_readiness_date_workaround(token_store: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def handler(url: str, params: dict[str, str], headers: dict[str, str]) -> DummyResponse:
+        calls.append({"url": url, "params": params, "headers": headers})
+        return DummyResponse(payload={"data": []}, status=200)
+
+    patch_client_session(monkeypatch, handler)
+
+    client = OuraClient(token_store=token_store)
+    await client.fetch_daily_readiness("2026-04-20")
+
+    assert len(calls) == 1
+    assert calls[0]["url"] == f"{OURA_API_BASE_URL}/daily_readiness"
+    assert calls[0]["params"] == {"start_date": "2026-04-19", "end_date": "2026-04-21"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_daily_readiness_returns_none_when_day_not_found(
+    token_store: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {"data": [{"day": "2026-04-19"}, {"day": "2026-04-21"}]}
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload=payload, status=200),
+    )
+
+    client = OuraClient(token_store=token_store)
+    result = await client.fetch_daily_readiness("2026-04-20")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_daily_readiness_picks_matching_entry(
+    token_store: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {"day": "2026-04-19", "score": 30},
+            {
+                "day": "2026-04-20",
+                "score": 90,
+                "timestamp": "2026-04-20T00:00:00Z",
+                "contributors": {},
+            },
+            {"day": "2026-04-21", "score": 40},
+        ]
+    }
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload=payload, status=200),
+    )
+
+    client = OuraClient(token_store=token_store)
+    result = await client.fetch_daily_readiness("2026-04-20")
+
+    assert result is not None
+    assert result.score == 90
+
+
+@pytest.mark.asyncio
+async def test_fetch_daily_activity_success_and_metric_format(
+    token_store: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "data": [
+            {
+                "day": "2026-04-20",
+                "score": 87,
+                "timestamp": "2026-04-20T00:00:00Z",
+                "steps": 12430,
+                "active_calories": 520,
+                "high_activity_time": 1800,
+                "equivalent_walking_distance": 13200,
+                "inactivity_alerts": 3,
+                "average_met_minutes": 1.5,
+                "contributors": {
+                    "meet_daily_targets": 80,
+                    "move_every_hour": 70,
+                },
+            }
+        ]
+    }
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload=payload, status=200),
+    )
+
+    client = OuraClient(token_store=token_store)
+    result = await client.fetch_daily_activity("2026-04-20")
+
+    assert result is not None
+    assert result.score_label == "Optimal"
+    display_by_key = {metric.key: metric.value_display for metric in result.metrics}
+    assert display_by_key["steps"] == "12430歩"
+    assert display_by_key["active_calories"] == "520 kcal"
+    assert display_by_key["high_activity_time"] == "30分"
+    assert display_by_key["equivalent_walking_distance"] == "13.2 km"
+    assert display_by_key["inactivity_alerts"] == "3回"
+    assert display_by_key["average_met_minutes"] == "1.5"
+
+
+@pytest.mark.asyncio
+async def test_null_contributors_are_excluded(token_store: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "data": [
+            {
+                "day": "2026-04-20",
+                "score": 80,
+                "timestamp": "2026-04-20T06:00:00+09:00",
+                "contributors": {
+                    "previous_night": 70,
+                    "sleep_balance": None,
+                },
+            }
+        ]
+    }
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload=payload, status=200),
+    )
+
+    client = OuraClient(token_store=token_store)
+    result = await client.fetch_daily_readiness("2026-04-20")
+
+    assert result is not None
+    assert len(result.contributors) == 1
+    assert result.contributors[0].key == "previous_night"
+
+
+@pytest.mark.asyncio
+async def test_authorization_header_is_set(token_store: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def handler(url: str, params: dict[str, str], headers: dict[str, str]) -> DummyResponse:
+        calls.append({"url": url, "params": params, "headers": headers})
+        return DummyResponse(payload={"data": []}, status=200)
+
+    patch_client_session(monkeypatch, handler)
+
+    client = OuraClient(token_store=token_store)
+    await client.fetch_daily_readiness("2026-04-20")
+
+    assert calls[0]["headers"]["Authorization"] == "Bearer dummy-token"
+
+
+@pytest.mark.asyncio
+async def test_429_raises(token_store: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload={}, status=429),
+    )
+
+    client = OuraClient(token_store=token_store)
+
+    with pytest.raises(aiohttp.ClientResponseError, match="HTTP 429"):
+        await client.fetch_daily_readiness("2026-04-20")
+
+
+@pytest.mark.asyncio
+async def test_500_raises(token_store: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload={}, status=500),
+    )
+
+    client = OuraClient(token_store=token_store)
+
+    with pytest.raises(aiohttp.ClientResponseError, match="HTTP 500"):
+        await client.fetch_daily_activity("2026-04-20")
+
+
+@pytest.mark.asyncio
+async def test_empty_response_returns_none(token_store: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload={"data": []}, status=200),
+    )
+
+    client = OuraClient(token_store=token_store)
+    result = await client.fetch_daily_readiness("2026-04-20")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_called_once_per_fetch(
+    token_store: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_client_session(
+        monkeypatch,
+        lambda _url, _params, _headers: DummyResponse(payload={"data": []}, status=200),
+    )
+
+    client = OuraClient(token_store=token_store)
+    await client.fetch_daily_readiness("2026-04-20")
+    await client.fetch_daily_activity("2026-04-20")
+
+    assert token_store.get_access_token.await_count == 2

--- a/tests/integrations/oura/test_helpers.py
+++ b/tests/integrations/oura/test_helpers.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from times_esa_talk.integrations.oura.helpers import (
+    ACTIVITY_METRIC_LABELS,
+    CONTRIBUTOR_LABELS_ACTIVITY,
+    CONTRIBUTOR_LABELS_READINESS,
+    format_int_count,
+    format_jst_timestamp,
+    format_kcal,
+    format_meters_to_km,
+    format_seconds_to_hm,
+    score_to_activity_label,
+    score_to_readiness_label,
+)
+
+
+def test_score_to_readiness_label() -> None:
+    assert score_to_readiness_label(85) == "Optimal"
+    assert score_to_readiness_label(100) == "Optimal"
+    assert score_to_readiness_label(70) == "Good"
+    assert score_to_readiness_label(84) == "Good"
+    assert score_to_readiness_label(0) == "Pay Attention"
+    assert score_to_readiness_label(69) == "Pay Attention"
+    assert score_to_readiness_label(None) is None
+
+
+def test_score_to_activity_label() -> None:
+    assert score_to_activity_label(69) == "Below Average"
+
+
+def test_format_seconds_to_hm() -> None:
+    assert format_seconds_to_hm(0) == "0分"
+    assert format_seconds_to_hm(1800) == "30分"
+    assert format_seconds_to_hm(3600) == "1時間0分"
+    assert format_seconds_to_hm(9000) == "2時間30分"
+    assert format_seconds_to_hm(None) is None
+
+
+def test_format_meters_to_km() -> None:
+    assert format_meters_to_km(13200) == "13.2 km"
+    assert format_meters_to_km(-3000) == "-3.0 km"
+    assert format_meters_to_km(0) == "0.0 km"
+    assert format_meters_to_km(None) is None
+
+
+def test_format_kcal() -> None:
+    assert format_kcal(520) == "520 kcal"
+    assert format_kcal(None) is None
+
+
+def test_format_int_count() -> None:
+    assert format_int_count(12430, "歩") == "12430歩"
+    assert format_int_count(None, "歩") is None
+
+
+def test_format_jst_timestamp() -> None:
+    assert format_jst_timestamp("2026-04-20T06:00:00+09:00") == "2026-04-20 06:00 JST"
+    assert format_jst_timestamp("2026-04-20T00:00:00Z") == "2026-04-20 09:00 JST"
+    assert format_jst_timestamp(None) is None
+
+
+def test_contributor_labels_readiness_completeness() -> None:
+    expected_keys = {
+        "previous_night",
+        "sleep_balance",
+        "previous_day_activity",
+        "activity_balance",
+        "resting_heart_rate",
+        "hrv_balance",
+        "body_temperature",
+        "recovery_index",
+        "sleep_regularity",
+    }
+    assert set(CONTRIBUTOR_LABELS_READINESS.keys()) == expected_keys
+
+
+def test_contributor_labels_activity_completeness() -> None:
+    expected_keys = {
+        "meet_daily_targets",
+        "move_every_hour",
+        "recovery_time",
+        "stay_active",
+        "training_frequency",
+        "training_volume",
+    }
+    assert set(CONTRIBUTOR_LABELS_ACTIVITY.keys()) == expected_keys
+
+
+def test_activity_metric_labels_completeness() -> None:
+    expected_keys = {
+        "steps",
+        "active_calories",
+        "total_calories",
+        "equivalent_walking_distance",
+        "high_activity_time",
+        "medium_activity_time",
+        "low_activity_time",
+        "sedentary_time",
+        "resting_time",
+        "non_wear_time",
+        "high_activity_met_minutes",
+        "medium_activity_met_minutes",
+        "low_activity_met_minutes",
+        "sedentary_met_minutes",
+        "average_met_minutes",
+        "inactivity_alerts",
+        "target_calories",
+        "target_meters",
+        "meters_to_target",
+    }
+    assert set(ACTIVITY_METRIC_LABELS.keys()) == expected_keys


### PR DESCRIPTION
### Motivation
- Provide an Oura Ring integration to fetch daily readiness and activity data and present it in application-friendly types and formats.
- Normalize and format Oura metrics and timestamps (JST) for display, and map numeric scores to human-readable labels.
- Ensure robust behavior around API date ranges, authorization, and HTTP error handling via automated tests.

### Description
- Add `OuraClient` that uses `aiohttp` and a token store to fetch `daily_readiness` and `daily_activity` and returns typed `DailyReadiness` and `DailyActivity` models. 
- Add formatting and mapping helpers in `integrations/oura/helpers.py` (labels, score-to-label, timestamp conversion to JST, and metric formatting) and Pydantic types in `integrations/oura/types.py`.
- Add comprehensive unit tests in `tests/integrations/oura/` that mock `aiohttp.ClientSession` with `DummySession` to validate request params, authorization header, error handling, metric formatting, contributor filtering, and token usage.

### Testing
- Ran the integration unit tests with `pytest tests/integrations/oura/test_helpers.py` which exercise helper formatting and label mappings and they passed. 
- Ran the client unit tests with `pytest tests/integrations/oura/test_client.py` which validate API request construction, response parsing, error propagation, and metric displays and they passed. 
- Confirmed that token store usage and HTTP error handling are covered by tests that succeeded (including `429` and `500` cases raising `aiohttp.ClientResponseError`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9636ae1e483299fe0d06f355c6f67)